### PR TITLE
Add README to the Homebrew folder

### DIFF
--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,7 +1,7 @@
 OMERO installation via Homebrew
 ===============================
 
-This directory contains scripts for installing OMERO on clean Mac OS X:
+This directory contains scripts for installing OMERO on clean Mac OS X system:
 
 - [cleanup](cleanup) completely removes all content under `/usr/local` and
 is meant to be used by Continuous Integration jobs.

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,0 +1,15 @@
+OMERO installation via Homebrew
+===============================
+
+This directory contains scripts for installing OMERO on clean Mac OS X:
+
+- [cleanup](cleanup) completely removes all content under `/usr/local` and
+is meant to be used by Continuous Integration jobs.
+
+- [install_homebrew](install_homebrew) installs Homebrew on a fresh system,
+including Homebrew Python and adds the taps required for OME formula
+installation.
+
+- install_omero{major}{minor} installs the latest {major}.{minor} version of
+Bio-Formats and OMERO. Additionally, it starts and test the installed
+OMERO.server and OMERO.web client.

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -10,6 +10,7 @@ is meant to be used by Continuous Integration jobs.
 including Homebrew Python and adds the taps required for OME formula
 installation.
 
-- install_omero{major}{minor} installs the latest {major}.{minor} version of
-Bio-Formats and OMERO. Additionally, it starts and test the installed
-OMERO.server and OMERO.web client.
+- [install_omero44](install_omero44), [install_omero50](install_omero50)
+and [install_omero51](install_omero51) install the latest {major}.{minor}
+version of Bio-Formats and OMERO. Additionally, it starts and test the
+installed OMERO.server and OMERO.web client.


### PR DESCRIPTION
Like the `linux` and `windows` folders, this PR adds a README under the `homebrew` folder describing the intent of each script.