### PR TITLE
Preserve Homebrew cache

### DIFF
--- a/homebrew/cleanup
+++ b/homebrew/cleanup
@@ -13,4 +13,6 @@ pkill postgres || echo No PostgreSQL running
 
 # Clean existing Homebrew
 rm -rf /usr/local/* && rm -rf /usr/local/.git || echo No Homebrew found
-rm -rf /Library/Caches/Homebrew/* || echo No Homebrew cache found
+
+# Remove Homebre cache
+# rm -rf /Library/Caches/Homebrew/* || echo No Homebrew cache found


### PR DESCRIPTION
See history of https://ci.openmicroscopy.org/job/OME-5.1-merge-homebrew/  and  https://ci.openmicroscopy.org/job/OME-5.0-merge-homebrew/ 

Many instances of the Homebrew installation job have failed with

```
==> Downloading https://downloads.sf.net/project/machomebrew/Bottles/cloog-0.18.1.mavericks.bottle.2.tar.gz
Error: Failed to download resource "cloog"
Download failed: https://downloads.sf.net/project/machomebrew/Bottles/cloog-0.18.1.mavericks.bottle.2.tar.gz
Warning: Bottle installation failed: building from source.
Error: /usr/local/opt/pkg-config not present or broken
```

i.e. while fetching external dependencies. Since `brew` does not seem to have any built-in `retry` logic, this PR proposes to preserve the Homebrew cache from one build to another. This has the advantage of testing the installation more robustly and more quickly but it also implies we are not testing the full process.
