### PR TITLE
Do not install Genshi by default in the Homebrew installation script

### DIFF
--- a/homebrew/install_homebrew
+++ b/homebrew/install_homebrew
@@ -41,12 +41,6 @@ bin/brew doctor
 # dependencies may require sudo
 bin/brew install python
 
-# Install Genshi (OMERO and Bio-Formats requirement)
-bin/pip install -U genshi
-
-# Tap homebrew-science library (HDF5)
-bin/brew tap homebrew/science || echo "Already tapped"
-
 # Tap ome-alt library
 bin/brew tap ome/alt || echo "Already tapped"
 
@@ -61,3 +55,6 @@ if [ $TESTING_MODE ]; then
     # Repair formula symlinks after merge
     /usr/local/bin/brew tap --repair
 fi
+
+# Tap homebrew-science library (HDF5)
+bin/brew tap homebrew/science || echo "Already tapped"

--- a/homebrew/install_homebrew
+++ b/homebrew/install_homebrew
@@ -57,4 +57,4 @@ if [ $TESTING_MODE ]; then
 fi
 
 # Tap homebrew-science library (HDF5)
-bin/brew tap homebrew/science || echo "Already tapped"
+/usr/local/bin/brew tap homebrew/science || echo "Already tapped"

--- a/homebrew/install_omero44
+++ b/homebrew/install_omero44
@@ -12,6 +12,9 @@ export ICE=${ICE:-3.5}
 
 cd /usr/local
 
+# Install Genshi (OMERO and Bio-Formats requirement)
+bin/pip install -U genshi
+
 ###################################################################
 # Bio-Formats installation
 ###################################################################

--- a/homebrew/install_omero51
+++ b/homebrew/install_omero51
@@ -14,6 +14,9 @@ export HTTPPORT=${HTTPPORT:-8080}
 
 cd /usr/local
 
+# Install Genshi (OMERO and Bio-Formats requirement)
+bin/pip install -U genshi
+
 ###################################################################
 # Bio-Formats installation
 ###################################################################
@@ -21,7 +24,6 @@ cd /usr/local
 # Install Bio-Formats
 bin/brew install bioformats51
 VERBOSE=1 bin/brew test bioformats51
-
 
 ###################################################################
 # OMERO installation


### PR DESCRIPTION
With 5.0.7, Genshi should be bundled as part of the Bio-Formats source.
The `pip install Genshi` command is moved to formulas (4.4.x) requiring
it and will be removed from 5.1.0 eventually.

--depends-on https://github.com/ome/homebrew-alt/pull/71