### PR TITLE
Add sleep command to handle race conditions

### DIFF
--- a/homebrew/install_omero50
+++ b/homebrew/install_omero50
@@ -105,6 +105,7 @@ bin/omero web start
 
 # Test simple Web connection
 brew install wget
+sleep 30
 wget --keep-session-cookies --save-cookies cookies.txt http://localhost:$HTTPPORT/webclient/login/ -O csrf_index.html
 csrf=$(cat csrf_index.html | grep "name=\'csrfmiddlewaretoken\'"  | sed "s/.* value=\'\(.*\)\'.*/\1/")
 post_data="username=root&password=$ROOT_PASSWORD&csrfmiddlewaretoken=$csrf&server=1&noredirect=1"

--- a/homebrew/install_omero50
+++ b/homebrew/install_omero50
@@ -105,7 +105,7 @@ bin/omero web start
 
 # Test simple Web connection
 brew install wget
-sleep 30
+sleep 10
 wget --keep-session-cookies --save-cookies cookies.txt http://localhost:$HTTPPORT/webclient/login/ -O csrf_index.html
 csrf=$(cat csrf_index.html | grep "name=\'csrfmiddlewaretoken\'"  | sed "s/.* value=\'\(.*\)\'.*/\1/")
 post_data="username=root&password=$ROOT_PASSWORD&csrfmiddlewaretoken=$csrf&server=1&noredirect=1"

--- a/homebrew/install_omero51
+++ b/homebrew/install_omero51
@@ -101,7 +101,7 @@ bin/omero web start
 
 # Test simple Web connection
 brew install wget
-sleep 30
+sleep 10
 wget --keep-session-cookies --save-cookies cookies.txt http://localhost:$HTTPPORT/webclient/login/ -O csrf_index.html
 csrf=$(cat csrf_index.html | grep "name=\'csrfmiddlewaretoken\'"  | sed "s/.* value=\'\(.*\)\'.*/\1/")
 post_data="username=root&password=$ROOT_PASSWORD&csrfmiddlewaretoken=$csrf&server=1&noredirect=1"

--- a/homebrew/install_omero51
+++ b/homebrew/install_omero51
@@ -101,6 +101,7 @@ bin/omero web start
 
 # Test simple Web connection
 brew install wget
+sleep 30
 wget --keep-session-cookies --save-cookies cookies.txt http://localhost:$HTTPPORT/webclient/login/ -O csrf_index.html
 csrf=$(cat csrf_index.html | grep "name=\'csrfmiddlewaretoken\'"  | sed "s/.* value=\'\(.*\)\'.*/\1/")
 post_data="username=root&password=$ROOT_PASSWORD&csrfmiddlewaretoken=$csrf&server=1&noredirect=1"


### PR DESCRIPTION
See https://ci.openmicroscopy.org/job/OME-5.1-merge-homebrew/ history. Many recent instances of the job have been failing while testing the Web client with a `502 bad gateway` error.
This can be reproduced locally by calling

```
omero web restart && 
wget --keep-session-cookies --save-cookies cookies.txt http://localhost:$HTTPPORT/webclient/login/ -O csrf_index.html
```

To prevent race conditions, this PR adds a `sleep` command between the start of the Web client and the test is launched.