### PR TITLE
5.1.0-m4 release requires nginx-development

### DIFF
--- a/homebrew/install_omero51
+++ b/homebrew/install_omero51
@@ -97,7 +97,7 @@ bin/omero logout
 # Start OMERO.web
 bin/omero config set omero.web.application_server "fastcgi-tcp"
 bin/omero config set omero.web.debug True
-bin/omero web config nginx --http $HTTPPORT > /usr/local/etc/nginx/omero.conf
+bin/omero web config nginx-development --http $HTTPPORT > /usr/local/etc/nginx/omero.conf
 nginx -c /usr/local/etc/nginx/omero.conf
 bin/omero web start
 


### PR DESCRIPTION
`omero web config nginx` has changed to `nginx-development`
https://github.com/openmicroscopy/openmicroscopy/pull/3354
https://github.com/ome/homebrew-alt/pull/73