### PR TITLE
Handle stricter --name rules

### DIFF
--- a/linux/test/docker-build.sh
+++ b/linux/test/docker-build.sh
@@ -13,7 +13,7 @@ cp ../*.sh ../*.env ../*init.d omero-install-test
 zip -r $1/omero-install-test.zip omero-install-test
 rm -rf omero-install-test
 
-IMAGE=omero-install-test-$1
+IMAGE=omero_install_test_${1%*/}
 echo "Building image $IMAGE"
 docker build -t $IMAGE --no-cache $1
 echo "Test this image by running docker run -it [...] $IMAGE"


### PR DESCRIPTION
Newer docker rules on the image names broke the
build script. `[a-zA-Z_0-9]` is now all that's
allowed.


cc: @sbesson @manics 