### PR TITLE
Make sure pip is upgraded

### DIFF
--- a/homebrew/install_homebrew
+++ b/homebrew/install_homebrew
@@ -40,6 +40,7 @@ bin/brew doctor
 # Alternately, the system Python can be used but installing Python
 # dependencies may require sudo
 bin/brew install python
+bin/pip install --upgrade pip setuptools
 
 # Tap ome-alt library
 bin/brew tap ome/alt || echo "Already tapped"


### PR DESCRIPTION
See https://github.com/pypa/pip/commit/368294be59445592cc50551c9a658248912ec10b

Previous version of pip bundled with the Python bottle prevented usage of scc. This commit ensure pip self-upgrades after installation while the bottle is not updated in the upstream repository