### PR TITLE
Full depth tap

### DIFF
--- a/homebrew/install_homebrew
+++ b/homebrew/install_homebrew
@@ -42,7 +42,7 @@ bin/brew doctor
 bin/brew install python
 
 # Tap ome-alt library
-if [ $TESTING_MODE ]; then
+if [ "$TESTING_MODE" = true ]; then
     bin/brew tap --full ome/alt || echo "Already tapped"
 
     # Install scc tools

--- a/homebrew/install_homebrew
+++ b/homebrew/install_homebrew
@@ -42,9 +42,9 @@ bin/brew doctor
 bin/brew install python
 
 # Tap ome-alt library
-bin/brew tap ome/alt || echo "Already tapped"
-
 if [ $TESTING_MODE ]; then
+    bin/brew tap --full ome/alt || echo "Already tapped"
+
     # Install scc tools
     bin/pip install -U scc || echo "scc installed"
 
@@ -54,6 +54,8 @@ if [ $TESTING_MODE ]; then
 
     # Repair formula symlinks after merge
     /usr/local/bin/brew tap --repair
+else
+    bin/brew tap ome/alt || echo "Already tapped"
 fi
 
 # Tap homebrew-science library (HDF5)


### PR DESCRIPTION
homebrew tap does a `--depth=1` clone of https://github.com/ome/homebrew-alt into /usr/local/Library/Taps/ome/homebrew-alt

https://github.com/Homebrew/homebrew/blob/3f7dfcb20e3779c26063e134bbcebbb951e1e43a/Library/Homebrew/cmd/tap.rb#L24

This causes `scc merge` to fail if the PR was opened against an older version of `origin/master`

- https://ci.openmicroscopy.org/view/Failing/job/OME-5.1-merge-homebrew/ICE=3.5,OSX=snapper/121/console
- https://github.com/ome/homebrew-alt/pull/74/

- `git merge` fails to merge (reports conflicts) since the history is missing
- Conflicting PR detection fails because `git merge-base` returns empty

To reproduce:

```
git clone https://github.com/ome/homebrew-alt --depth=1
cd homebrew-alt
git remote add merge_rleigh-dundee git://github.com/rleigh-dundee/homebrew-alt.git
git fetch merge_rleigh-dundee
#git log -n1 merge_rleigh-dundee/bfcpp51-alt
git merge --no-ff -m test 4a75b8ed9ebab714b64f696343f5d54a239ed38d
# Fails
git merge-base 651a1826ebcf87a01c4fa0f8da31e46274d332cc 4a75b8ed9ebab714b64f696343f5d54a239ed38d
# Returns nothing
```

Also fix the `$TESTING_MODE` test