### PR TITLE
Use exec bash at end of docker test run.sh scripts

### DIFF
--- a/linux/test/centos6-apache/run.sh
+++ b/linux/test/centos6-apache/run.sh
@@ -4,4 +4,4 @@ service crond start
 service omero start
 service httpd start
 service omero-web start
-bash
+exec bash

--- a/linux/test/centos6/run.sh
+++ b/linux/test/centos6/run.sh
@@ -4,4 +4,4 @@ service crond start
 service omero start
 service nginx start
 service omero-web start
-bash
+exec bash

--- a/linux/test/ubuntu1404/run.sh
+++ b/linux/test/ubuntu1404/run.sh
@@ -5,4 +5,4 @@ cron
 service omero start
 service nginx start
 service omero-web start
-bash
+exec bash


### PR DESCRIPTION
As reported by @joshmoore the `centos6-apache` container was exiting immediately after startup. I'm not sure why but I suspect the parent shell was receiving a termination signal and therefore killing its child bash. Use `exec bash` instead (though if something else is exiting this will probably lead to zombies).

Obviously this is all bad practice for Docker, but these are purely for testing the ome-install scripts.