### PR TITLE
Homebrew: install OMERO 5.1 with --with-cpp option turned on

### DIFF
--- a/homebrew/install_omero51
+++ b/homebrew/install_omero51
@@ -29,7 +29,7 @@ VERBOSE=1 bin/brew test bioformats51
 # Install PostgreSQL and OMERO
 OMERO_PYTHONPATH=$(bin/brew --prefix omero51)/lib/python
 if [ "$ICE" == "3.4" ]; then
-    bin/brew install omero51 --with-ice34 --with-nginx --with-cpp
+    bin/brew install omero51 --with-ice34 --with-nginx
     ICE_HOME=$(bin/brew --prefix zeroc-ice34)
     export PYTHONPATH=$OMERO_PYTHONPATH:$ICE_HOME/python
     export DYLD_LIBRARY_PATH=$ICE_HOME/lib

--- a/homebrew/install_omero51
+++ b/homebrew/install_omero51
@@ -29,12 +29,12 @@ VERBOSE=1 bin/brew test bioformats51
 # Install PostgreSQL and OMERO
 OMERO_PYTHONPATH=$(bin/brew --prefix omero51)/lib/python
 if [ "$ICE" == "3.4" ]; then
-    bin/brew install omero51 --with-ice34 --with-nginx
+    bin/brew install omero51 --with-ice34 --with-nginx --with-cpp
     ICE_HOME=$(bin/brew --prefix zeroc-ice34)
     export PYTHONPATH=$OMERO_PYTHONPATH:$ICE_HOME/python
     export DYLD_LIBRARY_PATH=$ICE_HOME/lib
 else
-    bin/brew install omero51 --with-nginx
+    bin/brew install omero51 --with-nginx --with-cpp
     export PYTHONPATH=$OMERO_PYTHONPATH
 fi
 VERBOSE=1 bin/brew test omero51


### PR DESCRIPTION
This should allow to test https://github.com/ome/homebrew-alt/pull/84 and have the `--with-cpp` option tested daily.