### PR TITLE
make it more obvious that settings.env is not a secvuln

### DIFF
--- a/linux/settings.env
+++ b/linux/settings.env
@@ -1,3 +1,6 @@
+# This file is just an example that you may use as a template.
+# Substitute the variables' values with those appropriate for your server.
+
 OMERO_DB_USER=db_user
 OMERO_DB_PASS=db_password
 OMERO_DB_NAME=omero_database


### PR DESCRIPTION
With luck this will stop people finding http://www.openmicroscopy.org/site/support/omero5.1/_downloads/settings.env and reporting its availability as a security vulnerability.