### PR TITLE
Bump Ice 3.5.1 build numbers for Windows installation

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -19,7 +19,7 @@ Note that due to a bug(?) in the Python installer it is not possible to do an un
 
 - jre-8u45-windows-x64.exe
 - postgresql-9.4.1-3-windows-x64.exe
-- Ice-3.5.1-b3-win-x64-Release.zip
+- Ice-3.5.1-b4-win-x64-Release.zip
 - python-2.7.9\python-2.7.9.amd64.msi
 
 Install Python module dependencies (all the whl files in the `python-2.7.9` directory). These are wheel files which must be installed using pip:

--- a/windows/setup_windows.bat
+++ b/windows/setup_windows.bat
@@ -14,12 +14,12 @@ start /w jre-8u45-windows-x64.exe /s
 start /w postgresql-9.4.1-3-windows-x64.exe --mode unattended
 
 
-rmdir /s /q Ice-3.5.1-b3-win-x64-Release
-start /w cscript j_unzip.vbs Ice-3.5.1-b3-win-x64-Release.zip
-rem move Ice-3.5.1-b3-win-x64-Release c:\
-xcopy /e /i Ice-3.5.1-b3-win-x64-Release c:\Ice-3.5.1-b3-win-x64-Release
+rmdir /s /q Ice-3.5.1-b4-win-x64-Release
+start /w cscript j_unzip.vbs Ice-3.5.1-b4-win-x64-Release.zip
+rem move Ice-3.5.1-b4-win-x64-Release c:\
+xcopy /e /i Ice-3.5.1-b4-win-x64-Release c:\Ice-3.5.1-b4-win-x64-Release
 
 
-IF DEFINED PYTHONPATH (setx /m PYTHONPATH "c:\Ice-3.5.1-b3-win-x64-Release\python;%PYTHONPATH%") ELSE (setx /m PYTHONPATH "c:\Ice-3.5.1-b3-win-x64-Release\python")
+IF DEFINED PYTHONPATH (setx /m PYTHONPATH "c:\Ice-3.5.1-b4-win-x64-Release\python;%PYTHONPATH%") ELSE (setx /m PYTHONPATH "c:\Ice-3.5.1-b4-win-x64-Release\python")
 
-setx /m PATH "c:\Ice-3.5.1-b3-win-x64-Release\bin;c:\Ice-3.5.1-b3-win-x64-Release\lib;c:\Program Files\Java\jre1.8.0_45\bin;c:\Python27;c:\Program Files\PostgreSQL\9.4\bin;%PATH%"
+setx /m PATH "c:\Ice-3.5.1-b4-win-x64-Release\bin;c:\Ice-3.5.1-b4-win-x64-Release\lib;c:\Program Files\Java\jre1.8.0_45\bin;c:\Python27;c:\Program Files\PostgreSQL\9.4\bin;%PATH%"


### PR DESCRIPTION
This should update the installation scripts to use the latest build of the Ice 3.5 packages for Windows.