### PR TITLE
Install Django 1.6.11 as a Python dependency

### DIFF
--- a/windows/setup_python_deps.bat
+++ b/windows/setup_python_deps.bat
@@ -1,5 +1,6 @@
 set PYTHONPIP=C:\Python27\Scripts\pip.exe
 
+%PYTHONPIP% install python-2.7.9\Django-1.8.5-py2.py3-none-any.whl
 %PYTHONPIP% install python-2.7.9\matplotlib-1.4.3-cp27-none-win_amd64.whl
 %PYTHONPIP% install python-2.7.9\numpy-1.9.2+mkl-cp27-none-win_amd64.whl
 %PYTHONPIP% install python-2.7.9\numexpr-2.4.3-cp27-none-win_amd64.whl

--- a/windows/setup_python_deps.bat
+++ b/windows/setup_python_deps.bat
@@ -1,6 +1,6 @@
 set PYTHONPIP=C:\Python27\Scripts\pip.exe
 
-%PYTHONPIP% install python-2.7.9\Django-1.8.5-py2.py3-none-any.whl
+%PYTHONPIP% install python-2.7.9\Django-1.6.11-py2.py3-none-any.whl
 %PYTHONPIP% install python-2.7.9\matplotlib-1.4.3-cp27-none-win_amd64.whl
 %PYTHONPIP% install python-2.7.9\numpy-1.9.2+mkl-cp27-none-win_amd64.whl
 %PYTHONPIP% install python-2.7.9\numexpr-2.4.3-cp27-none-win_amd64.whl


### PR DESCRIPTION
This should allow to deploy OMERO.web 5.2.0 on a Windows environment

The corresponding whl file is under `/ome/team/sbesson/omero-install/windows/python-2.7.9` 

/cc @manics @aleksandra-tarkowska 