### PR TITLE
Change CentOS 6 walkthrough to install Python 2.7 and recompile Ice

### DIFF
--- a/linux/dependencies-centos6-ice.sh
+++ b/linux/dependencies-centos6-ice.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+yum -y install tar
+
+mkdir /tmp/ice
+cd /tmp/ice
+
+curl -Lo Ice-3.5.1.tar.gz https://zeroc.com/download/Ice/3.5/Ice-3.5.1.tar.gz
+
+tar xvf Ice-3.5.1.tar.gz
+cd Ice-3.5.1
+
+cd cpp
+make && make test && make install
+cd ../py
+set +u
+source /opt/rh/python27/enable
+set -u
+make && make test && make install
+

--- a/linux/dependencies-centos6-ice.sh
+++ b/linux/dependencies-centos6-ice.sh
@@ -18,3 +18,6 @@ source /opt/rh/python27/enable
 set -u
 make && make test && make install
 
+echo /opt/Ice-3.5.1/lib64 > /etc/ld.so.conf.d/ice-x86_64.conf
+ldconfig
+

--- a/linux/dependencies-centos6.sh
+++ b/linux/dependencies-centos6.sh
@@ -11,12 +11,7 @@ yum -y install \
 	wget \
 	java-1.8.0-openjdk \
 	db53 db53-devel db53-utils mcpp-devel
-	#ice ice-python ice-servers
 
-#yum -y install \
-	#python-pip python-devel python-virtualenv \
-	#numpy scipy python-matplotlib Cython \
-	#gcc \
 yum -y install \
 	python27 \
 	python27-numpy \
@@ -32,15 +27,6 @@ yum -y install \
 
 # TODO: this installs a lot of unecessary packages:
 yum -y groupinstall "Development Tools"
-
-# Requires gcc {libjpeg,libpng,libtiff,zlib}-devel
-#pip install pillow
-#pip install numexpr==1.4.2
-# Requires gcc, Cython, hdf5-devel
-#pip install tables==2.4.0
-
-# Django
-#pip install Django==1.6.11
 
 set +u
 source /opt/rh/python27/enable

--- a/linux/dependencies-centos6.sh
+++ b/linux/dependencies-centos6.sh
@@ -46,8 +46,12 @@ set +u
 source /opt/rh/python27/enable
 set -u
 easy_install pip
+
 export PYTHONWARNINGS="ignore:Unverified HTTPS request"
 pip install tables pillow matplotlib
+
+# Django
+pip install "Django<1.9"
 
 # Postgres, reconfigure to allow TCP connections
 yum -y install http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-1.noarch.rpm

--- a/linux/dependencies-centos6.sh
+++ b/linux/dependencies-centos6.sh
@@ -27,7 +27,7 @@ yum -y install \
 	hdf5-devel \
 	freetype-devel \
 	expat-devel \
-	libbz2-devel \
+	bzip2-devel \
 	openssl-devel
 
 # TODO: this installs a lot of unecessary packages:

--- a/linux/dependencies-centos6.sh
+++ b/linux/dependencies-centos6.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 yum -y install epel-release
+yum -y install centos-release-SCL
 
 curl -o /etc/yum.repos.d/zeroc-ice-el6.repo \
 	http://download.zeroc.com/Ice/3.5/el6/zeroc-ice-el6.repo
@@ -8,27 +9,45 @@ curl -o /etc/yum.repos.d/zeroc-ice-el6.repo \
 yum -y install \
 	unzip \
 	wget \
-	java-1.7.0-openjdk \
-	ice ice-python ice-servers
+	java-1.8.0-openjdk \
+	db53 db53-devel db53-utils mcpp-devel
+	#ice ice-python ice-servers
 
+#yum -y install \
+	#python-pip python-devel python-virtualenv \
+	#numpy scipy python-matplotlib Cython \
+	#gcc \
 yum -y install \
-	python-pip python-devel python-virtualenv \
-	numpy scipy python-matplotlib Cython \
-	gcc \
+	python27 \
+	python27-numpy \
 	libjpeg-devel \
 	libpng-devel \
 	libtiff-devel \
 	zlib-devel \
-	hdf5-devel
+	hdf5-devel \
+	freetype-devel \
+	expat-devel \
+	libbz2-devel \
+	openssl-devel
+
+# TODO: this installs a lot of unecessary packages:
+yum -y groupinstall "Development Tools"
 
 # Requires gcc {libjpeg,libpng,libtiff,zlib}-devel
-pip install pillow
-pip install numexpr==1.4.2
+#pip install pillow
+#pip install numexpr==1.4.2
 # Requires gcc, Cython, hdf5-devel
-pip install tables==2.4.0
+#pip install tables==2.4.0
 
 # Django
-pip install Django==1.6.11
+#pip install Django==1.6.11
+
+set +u
+source /opt/rh/python27/enable
+set -u
+easy_install pip
+export PYTHONWARNINGS="ignore:Unverified HTTPS request"
+pip install tables pillow matplotlib
 
 # Postgres, reconfigure to allow TCP connections
 yum -y install http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-1.noarch.rpm

--- a/linux/install.sh
+++ b/linux/install.sh
@@ -40,7 +40,7 @@ fi
 bash -eux system_setup.sh
 bash -eux setup_postgres.sh
 
-cp settings.env setup_$OMEROVER.sh ~omero
+cp settings.env omero-c6-py27.env setup_$OMEROVER.sh ~omero
 if [ $WEBSERVER = apache ]; then
 	cp setup_omero_apache.sh ~omero
 fi

--- a/linux/install.sh
+++ b/linux/install.sh
@@ -32,6 +32,7 @@ source settings.env
 
 if [ $DISTRO = centos6 ]; then
 	bash -eux dependencies-centos6.sh
+	bash -eux dependencies-centos6-ice.sh
 else
 	bash -eux dependencies-ubuntu1404.sh
 fi

--- a/linux/omero-c6-py27.env
+++ b/linux/omero-c6-py27.env
@@ -1,0 +1,8 @@
+# Environment file for OMERO
+
+source /opt/rh/python27/enable
+ICE_HOME=/opt/Ice-3.5.1
+export PATH="${ICE_HOME}/bin:$PATH"
+export LD_LIBRARY_PATH="${ICE_HOME}/lib64:${ICE_HOME}/lib:$LD_LIBRARY_PATH"
+export PYTHONPATH="${ICE_HOME}/python:$PYTHONPATH"
+export SLICEPATH="${ICE_HOME}/slice"

--- a/linux/setup_apache_centos6.sh
+++ b/linux/setup_apache_centos6.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-yum -y install httpd mod_wsgi
+yum -y install httpd24-httpd python27-mod_wsgi
 
 # See setup_omero_apache.sh for the apache config file creation
 
-cp ~omero/OMERO.server/apache.conf.tmp /etc/httpd/conf.d/omero-web.conf
+cp ~omero/OMERO.server/apache.conf.tmp /opt/rh/httpd24/root/etc/httpd/conf.d/omero-web.conf
 
-chkconfig httpd on
-service httpd start
+chkconfig httpd24-httpd on
+service httpd24-httpd start

--- a/linux/setup_nginx_centos6.sh
+++ b/linux/setup_nginx_centos6.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set +u
+source /opt/rh/python27/enable
+set -u
+
 cat << EOF > /etc/yum.repos.d/nginx.repo
 [nginx]
 name=nginx repo

--- a/linux/setup_omero.sh
+++ b/linux/setup_omero.sh
@@ -4,6 +4,10 @@ set -e -u -x
 
 source settings.env
 
+set +u
+source /opt/rh/python27/enable
+set -u
+
 SERVER=http://downloads.openmicroscopy.org/latest/omero5/server-ice35.zip
 
 wget $SERVER

--- a/linux/setup_omerodev.sh
+++ b/linux/setup_omerodev.sh
@@ -4,6 +4,10 @@ set -e -u -x
 
 source settings.env
 
+set +u
+source /opt/rh/python27/enable
+set -u
+
 virtualenv omego
 omego/bin/pip install omego
 

--- a/linux/system_setup.sh
+++ b/linux/system_setup.sh
@@ -3,5 +3,14 @@
 useradd -m omero
 chmod a+X ~omero
 
+cat << EOF >> ~omero/.bashrc
+source /opt/rh/python27/enable
+ICE_HOME=/opt/Ice-3.5.1
+PATH="\${ICE_HOME}/bin:$PATH"
+export LD_LIBRARY_PATH="\${ICE_HOME}/lib64:\${ICE_HOME}/lib:\$LD_LIBRARY_PATH"
+export PYTHONPATH="\${ICE_HOME}/python:\$PYTHONPATH"
+export SLICEPATH="\${ICE_HOME}/slice"
+EOF
+
 mkdir -p "$OMERO_DATA_DIR"
 chown omero "$OMERO_DATA_DIR"

--- a/linux/system_setup.sh
+++ b/linux/system_setup.sh
@@ -3,14 +3,7 @@
 useradd -m omero
 chmod a+X ~omero
 
-cat << EOF >> ~omero/.bashrc
-source /opt/rh/python27/enable
-ICE_HOME=/opt/Ice-3.5.1
-PATH="\${ICE_HOME}/bin:$PATH"
-export LD_LIBRARY_PATH="\${ICE_HOME}/lib64:\${ICE_HOME}/lib:\$LD_LIBRARY_PATH"
-export PYTHONPATH="\${ICE_HOME}/python:\$PYTHONPATH"
-export SLICEPATH="\${ICE_HOME}/slice"
-EOF
+echo source \~omero/omero-c6-py27.env >> ~omero/.bashrc
 
 mkdir -p "$OMERO_DATA_DIR"
 chown omero "$OMERO_DATA_DIR"

--- a/linux/test/centos6-apache/run.sh
+++ b/linux/test/centos6-apache/run.sh
@@ -2,5 +2,5 @@
 service postgresql-9.4 start
 service crond start
 service omero start
-service httpd start
+service httpd24-httpd start
 exec bash


### PR DESCRIPTION
Note this adds two new files, so if it is merged they'll need to be added to the docs walkthrough.

```
================================================================================
OMERO Diagnostics 5.2.0-ice35-b12
================================================================================
        
Commands:   java -version                  1.8.0     (/usr/bin/java)
Commands:   python -V                      2.7.5     (/opt/rh/python27/root/usr/bin/python -- 2 others)
Commands:   icegridnode --version          3.5.1     (/opt/Ice-3.5.1/bin/icegridnode)
Commands:   icegridadmin --version         3.5.1     (/opt/Ice-3.5.1/bin/icegridadmin)
Commands:   psql --version                 9.4.5     (/usr/bin/psql)

Server:     icegridnode                    running
Server:     Blitz-0                        active (pid = 750, enabled)
Server:     DropBox                        active (pid = 788, enabled)
Server:     FileServer                     active (pid = 797, enabled)
Server:     Indexer-0                      active (pid = 802, enabled)
Server:     MonitorServer                  active (pid = 942, enabled)
Server:     OMERO.Glacier2                 active (pid = 803, enabled)
Server:     OMERO.IceStorm                 active (pid = 845, enabled)
Server:     PixelData-0                    active (pid = 852, enabled)
Server:     Processor-0                    active (pid = 882, enabled)
Server:     Tables-0                       active (pid = 936, enabled)
Server:     TestDropBox                    inactive (enabled)

Log dir:    /home/omero/OMERO.server/var/log exists
Log files:  Blitz-0.log                    696.0 KB      errors=16   warnings=0   
Log files:  DropBox.log                    1.0 KB       
Log files:  FileServer.log                 0.0 KB       
Log files:  Indexer-0.log                  1.0 KB       
Log files:  MonitorServer.log              1.0 KB       
Log files:  OMEROweb.lock                  0.0 KB       
Log files:  OMEROweb.log                   2.0 KB        errors=0    warnings=1   
Log files:  OMEROweb_brokenrequest.lock    0.0 KB       
Log files:  OMEROweb_brokenrequest.log     0.0 KB       
Log files:  PixelData-0.log                2.0 KB       
Log files:  Processor-0.log                56.0 KB       errors=16   warnings=0   
Log files:  Tables-0.log                   0.0 KB       
Log files:  TestDropBox.log                n/a
Log files:  master.err                     0.0 KB       
Log files:  master.out                     0.0 KB       
Log files:  Total size                     0.76 MB


Environment:OMERO_HOME=(unset)             
Environment:OMERO_NODE=(unset)             
Environment:OMERO_MASTER=(unset)           
Environment:OMERO_USERDIR=(unset)          
Environment:OMERO_TMPDIR=(unset)           
Environment:PATH=/opt/Ice-3.5.1/bin:/opt/rh/python27/root/usr/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/home/omero/bin 
Environment:PYTHONPATH=/opt/Ice-3.5.1/python: 
Environment:ICE_HOME=(unset)               
Environment:LD_LIBRARY_PATH=/opt/Ice-3.5.1/lib64:/opt/Ice-3.5.1/lib:/opt/rh/python27/root/usr/lib64 
Environment:DYLD_LIBRARY_PATH=(unset)      

OMERO SSL port:4064                           
OMERO TCP port:4063                           
OMERO data dir:'/OMERO'                       Exists? True	Is writable? True
OMERO temp dir:'/home/omero/omero/tmp'        Exists? True	Is writable? True   (Size: 0)

JVM settings: Blitz-${index}                -Xmx7200m -XX:MaxPermSize=1g -XX:+IgnoreUnrecognizedVMOptions
JVM settings: Indexer-${index}              -Xmx4800m -XX:MaxPermSize=1g -XX:+IgnoreUnrecognizedVMOptions
JVM settings: PixelData-${index}            -Xmx7200m -XX:MaxPermSize=1g -XX:+IgnoreUnrecognizedVMOptions
JVM settings: Repository-${index}           -Xmx4800m -XX:MaxPermSize=1g -XX:+IgnoreUnrecognizedVMOptions

OMERO.web status... [RUNNING] (PID 1166)
Django version: 1.8.6
```