### PR TITLE
Add travis file for linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ env:
   - ENV=centos6
   - ENV=ubuntu1404
 script:
-    - cd linux/test && ./docker-build.sh $ENV && docker run -ti omero_install_test_$ENV
+    - cd linux/test && ./docker-build.sh $ENV && docker run -d omero_install_test_$ENV
     # Sadly, no test for Windows or OS X here.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ env:
   - ENV=centos6
   - ENV=ubuntu1404
 script:
-    - cd linux/test && ./docker-build.sh $ENV && docker run -ti omero-install-test-$ENV
+    - cd linux/test && ./docker-build.sh $ENV && docker run -ti omero_install_test_$ENV
     # Sadly, no test for Windows or OS X here.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: objective-c
+matrix:
+  fast_finish: true
+services:
+  - docker
+env:
+  - ENV=centos6
+  - ENV=ubuntu1404
+  - ENV=install_omero52
+script:
+    - if [[ $ENV == 'install*' ]]; then cd homebrew && sh $ENV; fi
+    - if [[ $ENV != 'install*' ]]; then cd linux/test && ./docker-build.sh $ENV && docker run -ti omero-install-test-$ENV; fi
+    # Sadly, no test for Windows here.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
-language: objective-c
-matrix:
-  fast_finish: true
+language: python
 services:
   - docker
 env:
   - ENV=centos6
   - ENV=ubuntu1404
-  - ENV=install_omero52
 script:
-    - if [[ $ENV == 'install*' ]]; then cd homebrew && sh $ENV; fi
-    - if [[ $ENV != 'install*' ]]; then cd linux/test && ./docker-build.sh $ENV && docker run -ti omero-install-test-$ENV; fi
-    # Sadly, no test for Windows here.
+    - cd linux/test && ./docker-build.sh $ENV && docker run -ti omero-install-test-$ENV
+    # Sadly, no test for Windows or OS X here.

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ services:
   - docker
 env:
   - ENV=centos6
+  - ENV=centos6-apache
   - ENV=ubuntu1404
 script:
     - cd linux/test && ./docker-build.sh $ENV && docker run -d omero_install_test_$ENV

--- a/linux/test/README.md
+++ b/linux/test/README.md
@@ -6,8 +6,8 @@ This directory contains Dockerfiles for testing the installation walkthroughs.
 For example:
 
     ./docker-build.sh ubuntu1404
-    docker run -it omero-install-test-ubuntu1404
+    docker run -it omero_install_test_ubuntu1404
 
     ./docker-build.sh centos6
-    docker run -it omero-install-test-centos6
+    docker run -it omero_install_test_centos6
 


### PR DESCRIPTION
Use docker in travis to test the `linux/` subdir of this repo.

NB: We'd likely need to add appveyor to test Windows.