### PR TITLE
Clean Docker shutdown

### DIFF
--- a/linux/docker-shutdown-centos6.sh
+++ b/linux/docker-shutdown-centos6.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# All that's needed to get a clean shutdown of the docker container
+
+service postgresql-9.4 stop

--- a/linux/docker-shutdown-ubuntu1404.sh
+++ b/linux/docker-shutdown-ubuntu1404.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# All that's needed to get a clean shutdown of the docker container
+
+service postgresql stop

--- a/linux/test/centos6-apache/Dockerfile
+++ b/linux/test/centos6-apache/Dockerfile
@@ -14,7 +14,9 @@ RUN yum -y install cronie && \
 ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
-RUN cd omero-install-test && bash install-centos6-apache.sh
+RUN cd omero-install-test && \
+	bash install-centos6-apache.sh && \
+	bash docker-shutdown-centos6.sh
 ADD run.sh /home/omero/run.sh
 
 EXPOSE 80 4063 4064

--- a/linux/test/centos6/Dockerfile
+++ b/linux/test/centos6/Dockerfile
@@ -14,7 +14,9 @@ RUN yum -y install cronie && \
 ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
-RUN cd omero-install-test && bash install-centos6.sh
+RUN cd omero-install-test && \
+	bash install-centos6.sh && \
+	bash docker-shutdown-centos6.sh
 ADD run.sh /home/omero/run.sh
 
 EXPOSE 80 4063 4064

--- a/linux/test/centos6py27-apache/Dockerfile
+++ b/linux/test/centos6py27-apache/Dockerfile
@@ -14,7 +14,9 @@ RUN yum -y install cronie && \
 ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
-RUN cd omero-install-test && bash install-centos6py27-apache.sh
+RUN cd omero-install-test && \
+	bash install-centos6py27-apache.sh && \
+	bash docker-shutdown-centos6.sh
 ADD run.sh /home/omero/run.sh
 
 EXPOSE 80 4063 4064

--- a/linux/test/centos6py27/Dockerfile
+++ b/linux/test/centos6py27/Dockerfile
@@ -14,7 +14,9 @@ RUN yum -y install cronie && \
 ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
-RUN cd omero-install-test && bash install-centos6py27.sh
+RUN cd omero-install-test && \
+	bash install-centos6py27.sh && \
+	bash docker-shutdown-centos6.sh
 ADD run.sh /home/omero/run.sh
 
 EXPOSE 80 4063 4064

--- a/linux/test/ubuntu1404/Dockerfile
+++ b/linux/test/ubuntu1404/Dockerfile
@@ -8,7 +8,9 @@ RUN update-locale LANG=C.UTF-8
 ADD omero-install-test.zip /
 RUN apt-get update && apt-get -y install unzip && unzip omero-install-test.zip
 
-RUN cd omero-install-test && bash install-ubuntu1404.sh
+RUN cd omero-install-test && \
+	bash install-ubuntu1404.sh && \
+	bash docker-shutdown-ubuntu1404.sh
 ADD run.sh /home/omero/run.sh
 
 EXPOSE 80 4063 4064


### PR DESCRIPTION
Fixes the problem reported in https://trello.com/c/bJnOwspB/72-omero-install-startup-failure. Apparently, failure to stop `postgresql` before the Docker container is destroyed leaves the DB in an inconsistent state.
