### PR TITLE
Generate apache24 config for Apache 2.4

### DIFF
--- a/linux/install-centos6py27-apache.sh
+++ b/linux/install-centos6py27-apache.sh
@@ -15,11 +15,11 @@ bash -eux user_setup_centos6py27.sh
 bash -eux setup_postgres.sh
 
 cp settings.env omero-centos6py27.env setup_${OMEROVER}_centos6py27.sh ~omero
-cp setup_omero_apache.sh ~omero
+cp setup_omero_apache24.sh ~omero
 
 su - omero -c "bash -eux setup_${OMEROVER}_centos6py27.sh"
 
-su - omero -c "bash -eux setup_omero_apache.sh"
+su - omero -c "bash -eux setup_omero_apache24.sh"
 bash -eux setup_apache_centos6py27.sh
 
 bash -eux setup_centos6_selinux.sh

--- a/linux/setup_omero_apache24.sh
+++ b/linux/setup_omero_apache24.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e -u -x
+
+source settings.env
+
+OMERO.server/bin/omero config set omero.web.application_server wsgi
+OMERO.server/bin/omero web config apache24 --http "$OMERO_WEB_PORT" > OMERO.server/apache.conf.tmp
+OMERO.server/bin/omero web syncmedia


### PR DESCRIPTION
Generate an `apache24` configuration instead of the default when using Apache 2.4.

--depends-on https://github.com/openmicroscopy/openmicroscopy/pull/4328

To test you'll need to use the a CI build:

```
diff --git a/linux/install-centos6py27-apache.sh b/linux/install-centos6py27-apache.sh
index dc5cfea..73c800e 100644
--- a/linux/install-centos6py27-apache.sh
+++ b/linux/install-centos6py27-apache.sh
@@ -3,7 +3,7 @@
 set -e -u -x

 OMEROVER=omero
-#OMEROVER=omerodev
+OMEROVER=omerodev

 source settings.env

diff --git a/linux/setup_omerodev_centos6py27.sh b/linux/setup_omerodev_centos6py27.sh
index 50766dd..2b91955 100644
--- a/linux/setup_omerodev_centos6py27.sh
+++ b/linux/setup_omerodev_centos6py27.sh
@@ -11,7 +11,7 @@ set -u
 virtualenv omego
 omego/bin/pip install omego

-BRANCH=OMERO-DEV-latest
+BRANCH=OMERO-DEV-merge-build

 omego/bin/omego download --branch $BRANCH server
 ln -s OMERO.server-*/ OMERO.server
```
