### PR TITLE
Create docker for Ubuntu1404 with apache24

### DIFF
--- a/linux/install-ubuntu1404-apache.sh
+++ b/linux/install-ubuntu1404-apache.sh
@@ -13,11 +13,11 @@ bash -eux system_setup.sh
 bash -eux setup_postgres.sh
 
 cp settings.env setup_$OMEROVER.sh ~omero
-cp setup_omero_apache.sh ~omero
+cp setup_omero_apache24.sh ~omero
 
 su - omero -c "bash -eux setup_$OMEROVER.sh"
 
-su - omero -c "bash -eux setup_omero_apache.sh"
+su - omero -c "bash -eux setup_omero_apache24.sh"
 
 bash -eux setup_apache_ubuntu1404.sh
 

--- a/linux/install-ubuntu1404-apache.sh
+++ b/linux/install-ubuntu1404-apache.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e -u -x
+
+OMEROVER=omero
+#OMEROVER=omerodev
+
+source settings.env
+
+bash -eux dependencies-ubuntu1404.sh
+
+bash -eux system_setup.sh
+bash -eux setup_postgres.sh
+
+cp settings.env setup_$OMEROVER.sh ~omero
+cp setup_omero_apache.sh ~omero
+
+su - omero -c "bash -eux setup_$OMEROVER.sh"
+
+su - omero -c "bash -eux setup_omero_apache.sh"
+
+bash -eux setup_apache_ubuntu1404.sh
+
+#If you don't want to use the init.d scripts you can start OMERO manually:
+#su - omero -c "OMERO.server/bin/omero admin start"
+#su - omero -c "OMERO.server/bin/omero web start"
+
+bash -eux setup_omero_daemon_noweb_ubuntu1404.sh
+
+bash -eux setup_permissions.sh
+
+bash -eux setup_cron.sh
+
+#service omero start
+#service omero-web start

--- a/linux/setup_apache_ubuntu1404.sh
+++ b/linux/setup_apache_ubuntu1404.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-apt-get -y install nginx gunicorn
+apt-get -y install apache2 libapache2-mod-wsgi
 
-# See setup_omero*.sh for the nginx config file creation
+# See setup_omero*.sh for the apache config file creation
 
-cp ~omero/OMERO.server/nginx.conf.tmp /etc/nginx/sites-available/omero-web
-rm /etc/nginx/sites-enabled/default
-ln -s /etc/nginx/sites-available/omero-web /etc/nginx/sites-enabled/
+cp ~omero/OMERO.server/apache.conf.tmp /etc/apache2/sites-available/omero-web.conf
+a2dissite 000-default.conf
+a2ensite omero-web.conf
 
-service nginx start
+service apache2 start

--- a/linux/setup_apache_ubuntu1404.sh
+++ b/linux/setup_apache_ubuntu1404.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+apt-get -y install nginx gunicorn
+
+# See setup_omero*.sh for the nginx config file creation
+
+cp ~omero/OMERO.server/nginx.conf.tmp /etc/nginx/sites-available/omero-web
+rm /etc/nginx/sites-enabled/default
+ln -s /etc/nginx/sites-available/omero-web /etc/nginx/sites-enabled/
+
+service nginx start

--- a/linux/setup_omero_daemon_noweb_ubuntu1404.sh
+++ b/linux/setup_omero_daemon_noweb_ubuntu1404.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cp omero-init.d /etc/init.d/omero
+chmod a+x /etc/init.d/omero
+
+cp omero-web-init.d /etc/init.d/omero-web
+chmod a+x /etc/init.d/omero-web
+
+update-rc.d -f omero remove
+update-rc.d -f omero defaults 98 02
+update-rc.d -f omero-web remove
+update-rc.d -f omero-web defaults 98 02

--- a/linux/setup_omero_daemon_noweb_ubuntu1404.sh
+++ b/linux/setup_omero_daemon_noweb_ubuntu1404.sh
@@ -3,10 +3,5 @@
 cp omero-init.d /etc/init.d/omero
 chmod a+x /etc/init.d/omero
 
-cp omero-web-init.d /etc/init.d/omero-web
-chmod a+x /etc/init.d/omero-web
-
 update-rc.d -f omero remove
 update-rc.d -f omero defaults 98 02
-update-rc.d -f omero-web remove
-update-rc.d -f omero-web defaults 98 02

--- a/linux/test/README.md
+++ b/linux/test/README.md
@@ -11,3 +11,35 @@ For example:
     ./docker-build.sh centos6
     docker run -it omero_install_test_centos6
 
+Ubuntu 14.04 using apache needs the web configuration to be modified to
+enable the OMERO web server to run, see below.
+
+Installing development branches
+-------------------------------
+
+By default the installation uses the latest OMERO server release. To use
+a specific development build set,
+
+    OMEROVER=omerodev
+
+in the relevant `install-` script and in `setup_omerodev.sh` set `BRANCH`
+to the required branch. By default this tracks latest,
+
+    BRANCH=OMERO-DEV-latest
+
+but could, for instance, be set to track the merge branch,
+
+    BRANCH=OMERO-DEV-merge
+
+Ubuntu 14.04/apache testing
+===========================
+
+To enable the OMERO web server, once the Docker image is running modify
+the web configuration `/etc/apache2/sites-available/omero-web.conf` to
+switch `WSGISocketPrefix` from its current value to,
+
+    WSGISocketPrefix /var/run/wsgi
+
+Then restart the apache service,
+
+    service apache2 restart

--- a/linux/test/ubuntu1404-apache/Dockerfile
+++ b/linux/test/ubuntu1404-apache/Dockerfile
@@ -1,0 +1,15 @@
+# Dockerfile for testing the OMERO Linux installation instructions
+# Not intended for production use
+FROM ubuntu:14.04
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+RUN update-locale LANG=C.UTF-8
+
+ADD omero-install-test.zip /
+RUN apt-get update && apt-get -y install unzip && unzip omero-install-test.zip
+
+RUN cd omero-install-test && bash install-ubuntu1404-apache.sh
+ADD run.sh /home/omero/run.sh
+
+EXPOSE 80 4063 4064
+CMD ["/bin/bash", "-e", "/home/omero/run.sh"]

--- a/linux/test/ubuntu1404-apache/run.sh
+++ b/linux/test/ubuntu1404-apache/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+service postgresql start
+#service crond start # Doesn't work in Docker
+cron
+service omero start
+service nginx start
+service omero-web start
+exec bash

--- a/linux/test/ubuntu1404-apache/run.sh
+++ b/linux/test/ubuntu1404-apache/run.sh
@@ -3,6 +3,5 @@ service postgresql start
 #service crond start # Doesn't work in Docker
 cron
 service omero start
-service nginx start
-service omero-web start
+service apache2 start
 exec bash


### PR DESCRIPTION
This adds the apache 2.4 web deployment to the ubuntu 14.04 installation.

The standard build and docker start process should provide a running omero system. Note though that the web will not be functioning correctly, see https://github.com/manics/openmicroscopy/commit/d61d63a81df5023d202e1e5bfcfd9c292a6fa6d2 To run web:

 + modify `/etc/apache2/sites-available/omero-web.conf`
 + restart apache, `service apache2 restart`

the webclient will then be automatically available.