### PR TITLE
Apache centos7

### DIFF
--- a/linux/install-centos7-apache.sh
+++ b/linux/install-centos7-apache.sh
@@ -6,7 +6,7 @@ OMEROVER=omero
 
 for arg in "$@"; do
 	case "$arg" in
-	omero|omerodev|omerodevmerge)
+	omero|omerodev)
 		OMEROVER="$arg"
 		;;
 	*)

--- a/linux/install-centos7-apache.sh
+++ b/linux/install-centos7-apache.sh
@@ -31,7 +31,7 @@ if [ $OMEROVER = omerodev ]; then
 	su - omero -c "bash -eux setup_$OMEROVER.sh"
 fi 
 
-su - omero -c "bash -eux setup_omero_apache.sh"
+su - omero -c "bash -eux setup_omero_apache24.sh"
 bash -eux setup_apache_centos7.sh
 
 #If you don't want to use the systemd scripts you can start OMERO manually:

--- a/linux/install-centos7-apache.sh
+++ b/linux/install-centos7-apache.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e -u -x
+
+OMEROVER=omero
+
+for arg in "$@"; do
+	case "$arg" in
+	omero|omerodev|omerodevmerge)
+		OMEROVER="$arg"
+		;;
+	*)
+		echo "Unknown option: $arg";
+		exit 1
+	esac
+done
+
+source settings.env
+
+bash -eux dependencies-centos7.sh
+
+bash -eux system_setup.sh
+bash -eux setup_postgres.sh
+
+cp settings.env setup_$OMEROVER.sh ~omero
+cp setup_omero_apache.sh ~omero
+
+if [ $OMEROVER = omerodev ]; then
+	yum -y install python-virtualenv
+	yum clean all
+	su - omero -c "bash -eux setup_$OMEROVER.sh"
+fi 
+
+su - omero -c "bash -eux setup_omero_apache.sh"
+bash -eux setup_apache_centos7.sh
+
+#If you don't want to use the systemd scripts you can start OMERO manually:
+#su - omero -c "OMERO.server/bin/omero admin start"
+#su - omero -c "OMERO.server/bin/omero web start"
+
+bash -eux setup_omero_daemon_centos7.sh
+
+#systemctl start omero.service
+#systemctl start omero-web.service

--- a/linux/install-centos7-apache.sh
+++ b/linux/install-centos7-apache.sh
@@ -23,7 +23,7 @@ bash -eux system_setup.sh
 bash -eux setup_postgres.sh
 
 cp settings.env setup_$OMEROVER.sh ~omero
-cp setup_omero_apache.sh ~omero
+cp setup_omero_apache24.sh ~omero
 
 if [ $OMEROVER = omerodev ]; then
 	yum -y install python-virtualenv

--- a/linux/install-centos7-apache.sh
+++ b/linux/install-centos7-apache.sh
@@ -28,8 +28,8 @@ cp setup_omero_apache.sh ~omero
 if [ $OMEROVER = omerodev ]; then
 	yum -y install python-virtualenv
 	yum clean all
-	su - omero -c "bash -eux setup_$OMEROVER.sh"
 fi 
+su - omero -c "bash -eux setup_$OMEROVER.sh"
 
 su - omero -c "bash -eux setup_omero_apache24.sh"
 bash -eux setup_apache_centos7.sh

--- a/linux/install-centos7-apache.sh
+++ b/linux/install-centos7-apache.sh
@@ -4,17 +4,6 @@ set -e -u -x
 
 OMEROVER=omero
 
-for arg in "$@"; do
-	case "$arg" in
-	omero|omerodev)
-		OMEROVER="$arg"
-		;;
-	*)
-		echo "Unknown option: $arg";
-		exit 1
-	esac
-done
-
 source settings.env
 
 bash -eux dependencies-centos7.sh

--- a/linux/setup_apache_centos7.sh
+++ b/linux/setup_apache_centos7.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+yum -y install httpd mod_wsgi
+yum clean all
+
+# See setup_omero_apache.sh for the apache config file creation
+
+cp ~omero/OMERO.server/apache.conf.tmp /etc/httpd/conf.d/omero-web.conf
+
+rm -rf /run/httpd/* /tmp/httpd*
+
+systemctl enable httpd.service
+systemctl start httpd


### PR DESCRIPTION
Add option to use apache on centos7 
Follow the steps described in https://github.com/ome/omero-install/blob/master/linux/test/README.md
section: Centos 7 testing

To test this PR,
run `bash install-centos7-apache.sh omerodev`

Some files might be renamed depending on the outcome of the current name discussion see https://github.com/ome/omero-install/issues/46
