### PR TITLE
Remove Bio-Formats installation from install_omero51 script

### DIFF
--- a/homebrew/install_omero51
+++ b/homebrew/install_omero51
@@ -15,14 +15,6 @@ export HTTPPORT=${HTTPPORT:-8080}
 cd /usr/local
 
 ###################################################################
-# Bio-Formats installation
-###################################################################
-
-# Install Bio-Formats
-bin/brew install bioformats51
-VERBOSE=1 bin/brew test bioformats51
-
-###################################################################
 # OMERO installation
 ###################################################################
 


### PR DESCRIPTION
This step is now moved to a standalone job and does not need to be executed as part of the OMERO installation.