### PR TITLE
Travis: use omerodev for centos6py27-apache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
   - ENV=centos6py27
   - ENV=centos6py27-apache
   - ENV=ubuntu1404
+before_script:
+  - if [ "${ENV}" == "centos6py27-apache" ]; then sed -i -e 's|^OMEROVER=omero|&dev|g' linux/install-centos6py27-apache.sh; fi
 script:
     - cd linux/test && ./docker-build.sh $ENV && docker run -d omero_install_test_$ENV
     # Sadly, no test for Windows or OS X here.


### PR DESCRIPTION
An attempt to fix this:

```
Starting httpd: 91mAH00526: Syntax error on line 72 of /opt/rh/httpd24/root/etc/httpd/conf.d/omero-web.conf:
Either all Options must start with + or -, or no Option may.
```