### PR TITLE
Install requirements-py27-win.txt

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -50,18 +50,17 @@ Do a basic check of dependencies, you should not see any error messages when thi
 
     check.bat
 
-Setup IIS with Python:
-
-    setup_iis.bat
-
-- python-source\isapi_wsgi-0.4.2.zip
-
-Finally install and configure OMERO in the usual way:
+Install and configure OMERO in the usual way:
 
     setup_omero.bat
 
 - omero\OMERO.server-5.1.1-ice35-b43.zip
 
+Finally setup IIS with Python:
+
+    setup_iis.bat
+
+- python-source\isapi_wsgi-0.4.2.zip
 
 Optional prerequisites
 ----------------------

--- a/windows/setup_iis.bat
+++ b/windows/setup_iis.bat
@@ -1,5 +1,8 @@
 start /w dism /Online /Enable-Feature /FeatureName:IIS-WebServerRole /FeatureName:IIS-WebServer /FeatureName:IIS-CommonHttpFeatures /FeatureName:IIS-Security /FeatureName:IIS-RequestFiltering /FeatureName:IIS-StaticContent /FeatureName:IIS-DefaultDocument /FeatureName:IIS-DirectoryBrowsing /FeatureName:IIS-HttpErrors /FeatureName:IIS-ApplicationDevelopment /FeatureName:IIS-ISAPIExtensions /FeatureName:IIS-ISAPIFilter /FeatureName:IIS-HealthAndDiagnostics /FeatureName:IIS-HttpLogging /FeatureName:IIS-Performance /FeatureName:IIS-HttpCompressionStatic /FeatureName:IIS-WebServerManagementTools /FeatureName:IIS-ManagementConsole /FeatureName:IIS-IIS6ManagementCompatibility /FeatureName:IIS-Metabase
 
+set PYTHONPIP=C:\Python27\Scripts\pip.exe
+%PYTHONPIP% install -r c:\OMERO.server\share\web\requirements-py27-win.txt
+
 start /w cscript j_unzip.vbs python-source\isapi_wsgi-0.4.2.zip
 pushd isapi_wsgi-0.4.2
 python setup.py install

--- a/windows/setup_iis.bat
+++ b/windows/setup_iis.bat
@@ -8,3 +8,6 @@ pushd isapi_wsgi-0.4.2
 python setup.py install
 popd
 
+rem To start OMERO run
+rem bin\omero admin start
+rem bin\omero web iis

--- a/windows/setup_omero.bat
+++ b/windows/setup_omero.bat
@@ -16,7 +16,3 @@ python bin\omero config set omero.data.dir \OMERO
 rem python bin\omero config set omero.web.debug True
 
 popd
-
-rem To start OMERO run
-rem bin\omero admin start
-rem bin\omero web iis

--- a/windows/setup_python_deps.bat
+++ b/windows/setup_python_deps.bat
@@ -1,6 +1,5 @@
 set PYTHONPIP=C:\Python27\Scripts\pip.exe
 
-%PYTHONPIP% install python-2.7.9\Django-1.6.11-py2.py3-none-any.whl
 %PYTHONPIP% install python-2.7.9\matplotlib-1.4.3-cp27-none-win_amd64.whl
 %PYTHONPIP% install python-2.7.9\numpy-1.9.2+mkl-cp27-none-win_amd64.whl
 %PYTHONPIP% install python-2.7.9\numexpr-2.4.3-cp27-none-win_amd64.whl


### PR DESCRIPTION
Removed django from `setup_iis` script, and therefore added install call to `requirements-py27-win.txt`, see https://github.com/openmicroscopy/openmicroscopy/pull/4368
