### PR TITLE
Workaround for CentOS-7-1503-01

### DIFF
--- a/linux/step05_centos7_nginx.sh
+++ b/linux/step05_centos7_nginx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-yum -y install nginx python-gunicorn
+yum -y --enablerepo=cr install nginx python-gunicorn
 
 # See setup_omero*.sh for the nginx config file creation
 


### PR DESCRIPTION
Workaround to fix:

```
...
+ OMERO.server/bin/omero web config nginx --http 80
+ bash -eux step05_centos7_nginx.sh
+ yum -y install nginx python-gunicorn
Loaded plugins: fastestmirror, langpacks
Loading mirror speeds from cached hostfile
 * base: mirrors.melbourne.co.uk
 * epel: mirror.bytemark.co.uk
 * extras: mirror.bytemark.co.uk
 * updates: mirrors.melbourne.co.uk
Resolving Dependencies
--> Running transaction check
---> Package nginx.x86_64 1:1.6.3-7.el7 will be installed
--> Processing Dependency: nginx-filesystem = 1:1.6.3-7.el7 for package: 1:nginx-1.6.3-7.el7.x86_64
--> Processing Dependency: nginx-filesystem for package: 1:nginx-1.6.3-7.el7.x86_64
--> Processing Dependency: GeoIP for package: 1:nginx-1.6.3-7.el7.x86_64
--> Processing Dependency: libprofiler.so.0()(64bit) for package: 1:nginx-1.6.3-7.el7.x86_64
--> Processing Dependency: libGeoIP.so.1()(64bit) for package: 1:nginx-1.6.3-7.el7.x86_64
---> Package python-gunicorn.noarch 0:18.0-2.el7 will be installed
--> Running transaction check
---> Package GeoIP.x86_64 0:1.5.0-9.el7 will be installed
---> Package gperftools-libs.x86_64 0:2.4-5.el7 will be installed
--> Processing Dependency: libunwind.so.8()(64bit) for package: gperftools-libs-2.4-5.el7.x86_64
---> Package nginx-filesystem.noarch 1:1.6.3-7.el7 will be installed
--> Finished Dependency Resolution
Error: Package: gperftools-libs-2.4-5.el7.x86_64 (epel)
           Requires: libunwind.so.8()(64bit)
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```

Should be revised after CentOS 7.2 is released.

**Test**: Install OMERO on CentOS 7 VM using `install_centos7_nginx.sh` script
