### PR TITLE
ubuntu apache

### DIFF
--- a/linux/step05_ubuntu1404_apache24.sh
+++ b/linux/step05_ubuntu1404_apache24.sh
@@ -7,6 +7,7 @@ apt-get -y install apache2 libapache2-mod-wsgi
 
 # See setup_omero*.sh for the apache config file creation
 
+sed -i -r -e 's|(WSGISocketPrefix run/wsgi)|#\1|' -e 's|# (WSGISocketPrefix /var/run/wsgi)|\1|' ~omero/OMERO.server/apache.conf.tmp
 cp ~omero/OMERO.server/apache.conf.tmp /etc/apache2/sites-available/omero-web.conf
 a2dissite 000-default.conf
 a2ensite omero-web.conf


### PR DESCRIPTION
set value of WSGISocketPrefix in apache.conf.tmp
as suggested by @manics 

cc @hflynn 

To test: 
- edit `step04_all_omero.sh` file in `linux` folder
  - `SERVER=http://downloads.openmicroscopy.org/omero/5.2.1-rc1/artifacts/OMERO.server-5.2.1-rc1-ice35-b13.zip`
  - `unzip -q OMERO.server-5.2.1-rc1-ice35-b13.zip`
- in `test`: run `./docker-build.sh ubuntu1404_apache24/`
- when done run `docker run -it -p 2222:22 -p 4063:4063 -p 4064:4064 -p 8080:80 omero_install_test_ubuntu1404_apache24`
- start web manually `su - omero -c "OMERO.server/bin/omero web start"`
