### PR TITLE
Scl ice

### DIFF
--- a/linux/step01_centos6_py27_deps.sh
+++ b/linux/step01_centos6_py27_deps.sh
@@ -25,9 +25,7 @@ yum -y install \
 	zlib-devel \
 	hdf5-devel \
 	freetype-devel \
-	expat-devel \
-	bzip2-devel \
-	openssl-devel
+	expat-devel
 
 # TODO: this installs a lot of unecessary packages:
 yum -y groupinstall "Development Tools"

--- a/linux/step01_centos6_py27_deps.sh
+++ b/linux/step01_centos6_py27_deps.sh
@@ -36,7 +36,10 @@ set -u
 easy_install pip
 
 export PYTHONWARNINGS="ignore:Unverified HTTPS request"
-pip install tables pillow matplotlib
+pip install tables matplotlib
+
+# Cap Pillow version due to a limitation in OMERO.figure with v3.0.0
+pip install "Pillow<3.0"
 
 # Django
 pip install "Django>=1.8,<1.9"

--- a/linux/step01_centos6_py27_deps.sh
+++ b/linux/step01_centos6_py27_deps.sh
@@ -9,8 +9,11 @@ curl -o /etc/yum.repos.d/zeroc-ice-el6.repo \
 yum -y install \
 	unzip \
 	wget \
+	tar
+
+yum -y install \
 	java-1.8.0-openjdk \
-	db53 db53-devel db53-utils mcpp-devel
+	db53 db53-utils mcpp
 
 yum -y install \
 	python27 \
@@ -49,24 +52,18 @@ sed -i.bak -re 's/^(host.*)ident/\1md5/' /var/lib/pgsql/9.4/data/pg_hba.conf
 chkconfig postgresql-9.4 on
 service postgresql-9.4 start
 
-# Now get and build ice
-yum -y install tar
+# Now install ice
+mkdir /tmp/ice-download
+cd /tmp/ice-download
 
-mkdir /tmp/ice
-cd /tmp/ice
+wget http://downloads.openmicroscopy.org/ice/experimental/Ice-3.5.1-b1-centos6-sclpy27-x86_64.tar.gz
 
-curl -Lo Ice-3.5.1.tar.gz https://zeroc.com/download/Ice/3.5/Ice-3.5.1.tar.gz
+tar -zxvf /tmp/ice-download/Ice-3.5.1-b1-centos6-sclpy27-x86_64.tar.gz
 
-tar xvf Ice-3.5.1.tar.gz
-cd Ice-3.5.1
+# so we don't have to update ICE_HOME
+mv Ice-3.5.1-b1-centos6-sclpy27-x86_64 /opt/Ice-3.5.1
 
-cd cpp
-make && make test && make install
-cd ../py
-set +u
-source /opt/rh/python27/enable
-set -u
-make && make test && make install
-
+# make path to Ice globally accessible
+# if globally set, there is no need to export LD_LIBRARY_PATH
 echo /opt/Ice-3.5.1/lib64 > /etc/ld.so.conf.d/ice-x86_64.conf
 ldconfig


### PR DESCRIPTION
no longer install ice from source.
Follow the same strategy than the one used for ius python

This should also speed up the travis build
