### PR TITLE
Webapp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,12 @@ env:
   - ENV=ubuntu1404_apache24
   - ENV=debian8_nginx
   - ENV=debian8_apache24
+<<<<<<< HEAD
   - ENV=centos6_py27_ius_apache22
   - ENV=centos6_py27_ius_apache24
   - ENV=centos6_py27_ius_nginx
+=======
+>>>>>>> clean up
 
 before_install:  
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ env:
   - ENV=centos6_py27_ius_apache22
   - ENV=centos6_py27_ius_apache24
   - ENV=centos6_py27_ius_nginx
+
+before_install:  
+  - sudo apt-get update
+  - sudo apt-get install docker-engine
+
 before_script:
   - if [ "${ENV}" == "centos6_py27_apache24" ]; then sed -i -e 's|^OMEROVER=omero|&dev|g' linux/install_centos6_py27_apache24.sh; fi
   - if [ "${ENV}" == "ubuntu1404_apache24" ]; then sed -i -e 's|^OMEROVER=omero|&dev|g' linux/install_ubuntu1404_apache24.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,21 +10,14 @@ env:
   - ENV=ubuntu1404_apache24
   - ENV=debian8_nginx
   - ENV=debian8_apache24
-<<<<<<< HEAD
   - ENV=centos6_py27_ius_apache22
   - ENV=centos6_py27_ius_apache24
   - ENV=centos6_py27_ius_nginx
-=======
->>>>>>> clean up
 
 before_install:  
   - sudo apt-get update
   - sudo apt-get install docker-engine
 
-before_script:
-  - if [ "${ENV}" == "centos6_py27_apache24" ]; then sed -i -e 's|^OMEROVER=omero|&dev|g' linux/install_centos6_py27_apache24.sh; fi
-  - if [ "${ENV}" == "ubuntu1404_apache24" ]; then sed -i -e 's|^OMEROVER=omero|&dev|g' linux/install_ubuntu1404_apache24.sh; fi
-  - if [ "${ENV}" == "debian8_apache24"]; then sed -i -e 's|^OMEROVER=omero|&dev|g' linux/install_debian8_apache24.sh; fi
 script:
     - cd linux/test && ./docker-build.sh $ENV && docker run -d omero_install_test_$ENV
     # Sadly, no test for Windows or OS X here.

--- a/linux/install_centos6_apache22.sh
+++ b/linux/install_centos6_apache22.sh
@@ -15,11 +15,11 @@ bash -eux step03_all_postgres.sh
 cp settings.env step04_all_$OMEROVER.sh ~omero
 su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
-bash -eux step05_centos6_apache22.sh
-
 if [ $WEBAPPS = true ]; then
 	bash -eux step05_1_all_webapps.sh
 fi
+
+bash -eux step05_centos6_apache22.sh
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_centos6_apache22.sh
+++ b/linux/install_centos6_apache22.sh
@@ -16,7 +16,7 @@ cp settings.env step04_all_$OMEROVER.sh ~omero
 su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
 if [ $WEBAPPS = true ]; then
-	bash -eux step05_1_all_webapps.sh
+	PY_ENV=py26 bash -eux step05_1_all_webapps.sh
 fi
 
 bash -eux step05_centos6_apache22.sh

--- a/linux/install_centos6_apache22.sh
+++ b/linux/install_centos6_apache22.sh
@@ -3,7 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
-#OMEROVER=omerodev
+WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
 
@@ -16,6 +16,10 @@ cp settings.env step04_all_$OMEROVER.sh ~omero
 su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
 bash -eux step05_centos6_apache22.sh
+
+if [ $WEBAPPS = true ]; then
+	bash -eux step05_1_all_webapps.sh
+fi
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_centos6_nginx.sh
+++ b/linux/install_centos6_nginx.sh
@@ -19,7 +19,7 @@ su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 bash -eux step05_centos6_nginx.sh
 
 if [ $WEBAPPS = true ]; then
-	bash -eux step05_1_all_webapps.sh
+	PY_ENV=py26 bash -eux step05_1_all_webapps.sh
 fi
 
 #If you don't want to use the init.d scripts you can start OMERO manually:

--- a/linux/install_centos6_nginx.sh
+++ b/linux/install_centos6_nginx.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
+WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
 
@@ -16,6 +17,10 @@ cp settings.env step04_all_$OMEROVER.sh ~omero
 su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
 bash -eux step05_centos6_nginx.sh
+
+if [ $WEBAPPS = true ]; then
+	bash -eux step05_1_all_webapps.sh
+fi
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_centos6_py27_apache24.sh
+++ b/linux/install_centos6_py27_apache24.sh
@@ -18,7 +18,7 @@ su - omero -c "bash -eux step04_centos6_py27_${OMEROVER}.sh"
 bash -eux step05_centos6_py27_apache24.sh
 
 if [ $WEBAPPS = true ]; then
-	bash -eux step05_1_all_webapps.sh
+	PY_ENV=scl bash -eux step05_1_all_webapps.sh
 fi
 
 #If you don't want to use the init.d scripts you can start OMERO manually:

--- a/linux/install_centos6_py27_apache24.sh
+++ b/linux/install_centos6_py27_apache24.sh
@@ -16,7 +16,7 @@ cp settings.env omero-centos6py27.env step04_centos6_py27_${OMEROVER}.sh ~omero
 su - omero -c "bash -eux step04_centos6_py27_${OMEROVER}.sh"
 
 if [ $WEBAPPS = true ]; then
-	PY_ENV=scl bash -eux step05_1_all_webapps.sh
+	PY_ENV=py27_scl bash -eux step05_1_all_webapps.sh
 fi
 
 bash -eux step05_centos6_py27_apache24.sh

--- a/linux/install_centos6_py27_apache24.sh
+++ b/linux/install_centos6_py27_apache24.sh
@@ -15,11 +15,11 @@ bash -eux step03_all_postgres.sh
 cp settings.env omero-centos6py27.env step04_centos6_py27_${OMEROVER}.sh ~omero
 su - omero -c "bash -eux step04_centos6_py27_${OMEROVER}.sh"
 
-bash -eux step05_centos6_py27_apache24.sh
-
 if [ $WEBAPPS = true ]; then
 	PY_ENV=scl bash -eux step05_1_all_webapps.sh
 fi
+
+bash -eux step05_centos6_py27_apache24.sh
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_centos6_py27_apache24.sh
+++ b/linux/install_centos6_py27_apache24.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
+WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
 
@@ -15,6 +16,10 @@ cp settings.env omero-centos6py27.env step04_centos6_py27_${OMEROVER}.sh ~omero
 su - omero -c "bash -eux step04_centos6_py27_${OMEROVER}.sh"
 
 bash -eux step05_centos6_py27_apache24.sh
+
+if [ $WEBAPPS = true ]; then
+	bash -eux step05_1_all_webapps.sh
+fi
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_centos6_py27_ius_apache22.sh
+++ b/linux/install_centos6_py27_ius_apache22.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
+WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
 
@@ -16,6 +17,10 @@ OMEROVER=${OMEROVER} bash -eux step03_centos6_py27_ius_virtualenv_deps.sh
 cp settings.env omero-centos6py27ius.env step04_centos6_py27_ius_${OMEROVER}.sh ~omero
 
 su - omero -c "bash -eux step04_centos6_py27_ius_${OMEROVER}.sh"
+
+if [ $WEBAPPS = true ]; then
+	PY_ENV=py27_ius bash -eux step05_1_all_webapps.sh
+fi
 
 bash -eux step05_centos6_py27_ius_apache22.sh
 

--- a/linux/install_centos6_py27_ius_apache24.sh
+++ b/linux/install_centos6_py27_ius_apache24.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
+WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
 
@@ -16,6 +17,10 @@ OMEROVER=${OMEROVER} bash -eux step03_centos6_py27_ius_virtualenv_deps.sh
 cp settings.env omero-centos6py27ius.env step04_centos6_py27_ius_${OMEROVER}.sh ~omero
 
 su - omero -c "bash -eux step04_centos6_py27_ius_${OMEROVER}.sh"
+
+if [ $WEBAPPS = true ]; then
+	PY_ENV=py27_ius bash -eux step05_1_all_webapps.sh
+fi
 
 bash -eux step05_centos6_py27_ius_apache24.sh
 

--- a/linux/install_centos6_py27_ius_nginx.sh
+++ b/linux/install_centos6_py27_ius_nginx.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
+WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
 
@@ -18,6 +19,10 @@ cp settings.env omero-centos6py27ius.env step04_centos6_py27_ius_${OMEROVER}.sh 
 su - omero -c "bash -eux step04_centos6_py27_ius_${OMEROVER}.sh"
 
 bash -eux step05_centos6_py27_ius_nginx.sh
+
+if [ $WEBAPPS = true ]; then
+	PY_ENV=py27_ius bash -eux step05_1_all_webapps.sh
+fi
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_centos6_py27_nginx.sh
+++ b/linux/install_centos6_py27_nginx.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
+WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
 
@@ -16,6 +17,10 @@ cp settings.env omero-centos6py27.env step04_centos6_py27_${OMEROVER}.sh ~omero
 su - omero -c "bash -eux step04_centos6_py27_${OMEROVER}.sh"
 
 bash -eux step05_centos6_py27_nginx.sh
+
+if [ $WEBAPPS = true ]; then
+	bash -eux step05_1_all_webapps.sh
+fi
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_centos6_py27_nginx.sh
+++ b/linux/install_centos6_py27_nginx.sh
@@ -19,7 +19,7 @@ su - omero -c "bash -eux step04_centos6_py27_${OMEROVER}.sh"
 bash -eux step05_centos6_py27_nginx.sh
 
 if [ $WEBAPPS = true ]; then
-	bash -eux step05_1_all_webapps.sh
+	PY_ENV=scl bash -eux step05_1_all_webapps.sh
 fi
 
 #If you don't want to use the init.d scripts you can start OMERO manually:

--- a/linux/install_centos6_py27_nginx.sh
+++ b/linux/install_centos6_py27_nginx.sh
@@ -19,7 +19,7 @@ su - omero -c "bash -eux step04_centos6_py27_${OMEROVER}.sh"
 bash -eux step05_centos6_py27_nginx.sh
 
 if [ $WEBAPPS = true ]; then
-	PY_ENV=scl bash -eux step05_1_all_webapps.sh
+	PY_ENV=py27_scl bash -eux step05_1_all_webapps.sh
 fi
 
 #If you don't want to use the init.d scripts you can start OMERO manually:

--- a/linux/install_centos7_apache24.sh
+++ b/linux/install_centos7_apache24.sh
@@ -15,11 +15,11 @@ bash -eux step03_all_postgres.sh
 cp settings.env step04_all_$OMEROVER.sh ~omero
 su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
-bash -eux step05_centos7_apache24.sh
-
 if [ $WEBAPPS = true ]; then
 	bash -eux step05_1_all_webapps.sh
 fi
+
+bash -eux step05_centos7_apache24.sh
 
 #If you don't want to use the systemd scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_centos7_apache24.sh
+++ b/linux/install_centos7_apache24.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
+WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
 
@@ -15,6 +16,10 @@ cp settings.env step04_all_$OMEROVER.sh ~omero
 su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
 bash -eux step05_centos7_apache24.sh
+
+if [ $WEBAPPS = true ]; then
+	bash -eux step05_1_all_webapps.sh
+fi
 
 #If you don't want to use the systemd scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_centos7_nginx.sh
+++ b/linux/install_centos7_nginx.sh
@@ -2,6 +2,8 @@
 
 set -e -u -x
 
+WEBAPPS=${WEBAPPS:-false}
+
 source settings.env
 
 bash -eux step01_centos7_deps.sh
@@ -13,6 +15,10 @@ cp settings.env step04_all_omero.sh ~omero
 su - omero -c "bash -eux step04_all_omero.sh"
 
 bash -eux step05_centos7_nginx.sh
+
+if [ $WEBAPPS = true ]; then
+	bash -eux step05_1_all_webapps.sh
+fi
 
 #If you don't want to use the systemd scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_debian8_apache24.sh
+++ b/linux/install_debian8_apache24.sh
@@ -15,11 +15,11 @@ bash -eux step03_all_postgres.sh
 cp settings.env step04_all_$OMEROVER.sh ~omero
 su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
-bash -eux step05_ubuntu1404_apache24.sh
-
 if [ $WEBAPPS = true ]; then
 	bash -eux step05_1_all_webapps.sh
 fi
+
+bash -eux step05_ubuntu1404_apache24.sh
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_debian8_apache24.sh
+++ b/linux/install_debian8_apache24.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
+WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
 
@@ -15,6 +16,10 @@ cp settings.env step04_all_$OMEROVER.sh ~omero
 su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
 bash -eux step05_ubuntu1404_apache24.sh
+
+if [ $WEBAPPS = true ]; then
+	bash -eux step05_1_all_webapps.sh
+fi
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_debian8_nginx.sh
+++ b/linux/install_debian8_nginx.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
+WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
 
@@ -16,6 +17,10 @@ cp settings.env step04_all_$OMEROVER.sh ~omero
 su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
 bash -eux step05_ubuntu1404_nginx.sh
+
+if [ $WEBAPPS = true ]; then
+	bash -eux step05_1_all_webapps.sh
+fi
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_ubuntu1404_apache24.sh
+++ b/linux/install_ubuntu1404_apache24.sh
@@ -18,8 +18,6 @@ su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 bash -eux step05_ubuntu1404_apache24.sh
 
 if [ $WEBAPPS = true ]; then
-	#install git to install gallery
-	apt-get -y install git
 	bash -eux step05_1_all_webapps.sh
 fi
 

--- a/linux/install_ubuntu1404_apache24.sh
+++ b/linux/install_ubuntu1404_apache24.sh
@@ -3,7 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
-WEBAPPS=false
+WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
 

--- a/linux/install_ubuntu1404_apache24.sh
+++ b/linux/install_ubuntu1404_apache24.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
+WEBAPPS=false
 
 source settings.env
 
@@ -15,6 +16,12 @@ cp settings.env step04_all_$OMEROVER.sh ~omero
 su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
 bash -eux step05_ubuntu1404_apache24.sh
+
+if [ $WEBAPPS = true ]; then
+	#install git to install gallery
+	apt-get -y install git
+	bash -eux step05_1_all_webapps.sh
+fi
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_ubuntu1404_apache24.sh
+++ b/linux/install_ubuntu1404_apache24.sh
@@ -15,11 +15,11 @@ bash -eux step03_all_postgres.sh
 cp settings.env step04_all_$OMEROVER.sh ~omero
 su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
-bash -eux step05_ubuntu1404_apache24.sh
-
 if [ $WEBAPPS = true ]; then
 	bash -eux step05_1_all_webapps.sh
 fi
+bash -eux step05_ubuntu1404_apache24.sh
+
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/install_ubuntu1404_nginx.sh
+++ b/linux/install_ubuntu1404_nginx.sh
@@ -3,7 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
-WEBAPPS=false
+WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
 

--- a/linux/install_ubuntu1404_nginx.sh
+++ b/linux/install_ubuntu1404_nginx.sh
@@ -19,8 +19,6 @@ su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 bash -eux step05_ubuntu1404_nginx.sh
 
 if [ $WEBAPPS = true ]; then
-	#install git to install gallery
-	apt-get -y install git
 	bash -eux step05_1_all_webapps.sh
 fi
 #If you don't want to use the init.d scripts you can start OMERO manually:

--- a/linux/install_ubuntu1404_nginx.sh
+++ b/linux/install_ubuntu1404_nginx.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 OMEROVER=omero
+WEBAPPS=false
 
 source settings.env
 
@@ -17,6 +18,11 @@ su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
 bash -eux step05_ubuntu1404_nginx.sh
 
+if [ $WEBAPPS = true ]; then
+	#install git to install gallery
+	apt-get -y install git
+	bash -eux step05_1_all_webapps.sh
+fi
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"
 #su - omero -c "OMERO.server/bin/omero web start"

--- a/linux/step01_centos6_deps.sh
+++ b/linux/step01_centos6_deps.sh
@@ -22,7 +22,7 @@ yum -y install \
 	hdf5-devel
 
 # Requires gcc {libjpeg,libpng,libtiff,zlib}-devel
-pip install pillow
+pip install 'Pillow<3.0'
 pip install numexpr==1.4.2
 # Requires gcc, Cython, hdf5-devel
 pip install tables==2.4.0

--- a/linux/step05_1_all_webapps.sh
+++ b/linux/step05_1_all_webapps.sh
@@ -9,6 +9,11 @@ NAME_FIGURE=figure-1.2.0
 URL_WEBTAGGING=http://downloads.openmicroscopy.org/webtagging/1.3.0/webtagging-1.3.0.zip
 NAME_WEBTAGGING=webtagging-1.3.0
 
+# Gallery 
+URL_GALLERY=https://github.com/ome/gallery/archive/v1.0.0.zip
+NAME_GALLERY_ZIP=v1.0.0.zip
+NAME_GALLERY=gallery-1.0.0
+
 # Read parameter
 VIRTUALENV=false
 for arg in "$@"; do
@@ -48,6 +53,8 @@ su - omero -c "OMERO.server/bin/omero config append omero.web.ui.top_links '[\"T
 
 # Web gallery
 #clone the repository
-git clone https://github.com/ome/gallery.git
-mv gallery OMERO.server/lib/python/omeroweb/gallery
+wget $URL_GALLERY
+unzip -q $NAME_GALLERY_ZIP
+
+mv $NAME_GALLERY OMERO.server/lib/python/omeroweb/gallery
 su - omero -c "OMERO.server/bin/omero config append omero.web.apps '\"gallery\"'"

--- a/linux/step05_1_all_webapps.sh
+++ b/linux/step05_1_all_webapps.sh
@@ -29,9 +29,10 @@ mv $NAME_FIGURE OMERO.server/lib/python/omeroweb/figure
 
 echo "value=$PY_ENV"
 # Install required packages
-if [ "$PY_ENV" = "ius" ]; then
-	/home/omero/omeroenv/bin/pip2.7 install reportlab markdown
-elif [ "$PY_ENV" = "scl" ]; then
+if [ "$PY_ENV" = "py26" ]; then
+	pip install reportlab==2.7
+	pip install reportlab markdown
+elif [ "$PY_ENV" = "py27_scl" ]; then
 	set +u
 	source /opt/rh/python27/enable
 	set -u

--- a/linux/step05_1_all_webapps.sh
+++ b/linux/step05_1_all_webapps.sh
@@ -72,8 +72,3 @@ su - omero -c "OMERO.server/bin/omero config append omero.web.apps '\"webtest\"'
 
 su - omero -c "OMERO.server/bin/omero config append omero.web.ui.right_plugins '[\"ROIs\", \"webtest/webclient_plugins/right_plugin.rois.js.html\", \"image_roi_tab\"]'"
 su - omero -c "OMERO.server/bin/omero config append omero.web.ui.center_plugins '[\"Split View\", \"webtest/webclient_plugins/center_plugin.splitview.js.html\", \"split_view_panel\"]'"
-
-
-
-
-

--- a/linux/step05_1_all_webapps.sh
+++ b/linux/step05_1_all_webapps.sh
@@ -1,0 +1,53 @@
+
+#!/bin/bash
+
+# Figure details
+URL_FIGURE=http://downloads.openmicroscopy.org/figure/1.2.0/figure-1.2.0.zip
+NAME_FIGURE=figure-1.2.0
+
+# Web tagging details
+URL_WEBTAGGING=http://downloads.openmicroscopy.org/webtagging/1.3.0/webtagging-1.3.0.zip
+NAME_WEBTAGGING=webtagging-1.3.0
+
+# Read parameter
+VIRTUALENV=false
+for arg in "$@"; do
+	case "$arg" in ve)
+	VIRTUALENV=true;;
+	esac
+done
+
+# Add OMERO.figure
+cd ~omero
+wget $URL_FIGURE
+unzip -q $NAME_FIGURE.zip
+mv $NAME_FIGURE OMERO.server/lib/python/omeroweb/figure
+
+# Install required packages
+if [ $VIRTUALENV = true ]; then
+	/home/omero/omeroenv/bin/pip2.7 install reportlab markdown
+else
+	pip install reportlab markdown
+fi
+
+# Register the app
+su - omero -c "OMERO.server/bin/omero config append omero.web.apps '\"figure\"'"
+su - omero -c "OMERO.server/bin/omero config append omero.web.ui.top_links '[\"Figure\", \"figure_index\", {\"title\": \"Open Figure in new tab\", \"target\": \"figure\"}]'"
+
+# Webtagging
+wget $URL_WEBTAGGING
+unzip -q $NAME_WEBTAGGING.zip
+mv $NAME_WEBTAGGING/autotag OMERO.server/lib/python/omeroweb/autotag
+mv $NAME_WEBTAGGING/tagsearch OMERO.server/lib/python/omeroweb/tagsearch
+
+# Register the app
+su - omero -c "OMERO.server/bin/omero config append omero.web.apps '\"autotag\"'"
+su - omero -c "OMERO.server/bin/omero config append omero.web.apps '\"tagsearch\"'"
+su - omero -c "OMERO.server/bin/omero config append omero.web.ui.center_plugins '[\"Auto Tag\", \"autotag/auto_tag_init.js.html\", \"auto_tag_panel\"]'"
+su - omero -c "OMERO.server/bin/omero config append omero.web.ui.top_links '[\"Tag Search\", \"tagsearch\"]'"
+
+# Web gallery
+#clone the repository
+git clone https://github.com/ome/gallery.git
+mv gallery OMERO.server/lib/python/omeroweb/gallery
+su - omero -c "OMERO.server/bin/omero config append omero.web.apps '\"gallery\"'"

--- a/linux/step05_1_all_webapps.sh
+++ b/linux/step05_1_all_webapps.sh
@@ -44,6 +44,10 @@ fi
 su - omero -c "OMERO.server/bin/omero config append omero.web.apps '\"figure\"'"
 su - omero -c "OMERO.server/bin/omero config append omero.web.ui.top_links '[\"Figure\", \"figure_index\", {\"title\": \"Open Figure in new tab\", \"target\": \"figure\"}]'"
 
+# Copy the script 
+FOLDER=OMERO.server/lib/python/omeroweb/figure/scripts
+cp $FOLDER/omero/figure_scripts/Figure_To_Pdf.py OMERO.server/lib/scripts/omero/figure_scripts
+
 # Webtagging
 wget $URL_WEBTAGGING
 unzip -q $NAME_WEBTAGGING.zip

--- a/linux/step05_1_all_webapps.sh
+++ b/linux/step05_1_all_webapps.sh
@@ -1,7 +1,7 @@
 
 #!/bin/bash
 
-PY_ENV=${PY_ENV:-all}
+PY_ENV=${PY_ENV:-py27}
 
 # Figure details
 URL_FIGURE=http://downloads.openmicroscopy.org/figure/1.2.0/figure-1.2.0.zip

--- a/linux/step05_1_all_webapps.sh
+++ b/linux/step05_1_all_webapps.sh
@@ -3,29 +3,27 @@
 
 PY_ENV=${PY_ENV:-py27}
 
-# Figure details
-URL_FIGURE=http://downloads.openmicroscopy.org/figure/1.2.0/figure-1.2.0.zip
-NAME_FIGURE=figure-1.2.0
+# Figure URL
+URL_FIGURE=http://downloads.openmicroscopy.org/latest/figure.zip
 
-# Web tagging details
-URL_WEBTAGGING=http://downloads.openmicroscopy.org/webtagging/1.3.0/webtagging-1.3.0.zip
-NAME_WEBTAGGING=webtagging-1.3.0
+# Web tagging URL
+URL_WEBTAGGING=http://downloads.openmicroscopy.org/latest/webtagging.zip
 
-# Gallery 
+# Gallery URL
 URL_GALLERY=https://github.com/ome/gallery/archive/v1.0.0.zip
-NAME_GALLERY_ZIP=v1.0.0.zip
-NAME_GALLERY=gallery-1.0.0
 
-# web test
+# web test URL
 URL_WEBTEST=https://github.com/openmicroscopy/webtest/archive/master.zip
-NAME_WEBTEST_ZIP=master.zip
-NAME_WEBTEST=webtest-master
+
+cd ~omero
 
 # Add OMERO.figure
-cd ~omero
+NAME_FIGURE_ZIP=${URL_FIGURE##*/}
+
 wget $URL_FIGURE
-unzip -q $NAME_FIGURE.zip
-mv $NAME_FIGURE OMERO.server/lib/python/omeroweb/figure
+unzip -q $NAME_FIGURE_ZIP
+rm $NAME_FIGURE_ZIP
+mv figure* OMERO.server/lib/python/omeroweb/figure
 
 echo "value=$PY_ENV"
 # Install required packages
@@ -57,10 +55,14 @@ FOLDER=OMERO.server/lib/python/omeroweb/figure/scripts
 cp $FOLDER/omero/figure_scripts/Figure_To_Pdf.py OMERO.server/lib/scripts/omero/figure_scripts
 
 # Webtagging
+NAME_WEBTAGGING_ZIP=${URL_WEBTAGGING##*/}
+
 wget $URL_WEBTAGGING
-unzip -q $NAME_WEBTAGGING.zip
-mv $NAME_WEBTAGGING/autotag OMERO.server/lib/python/omeroweb/autotag
-mv $NAME_WEBTAGGING/tagsearch OMERO.server/lib/python/omeroweb/tagsearch
+unzip -q $NAME_WEBTAGGING_ZIP
+rm $NAME_WEBTAGGING_ZIP
+
+mv webtagging*/autotag OMERO.server/lib/python/omeroweb/autotag
+mv webtagging*/tagsearch OMERO.server/lib/python/omeroweb/tagsearch
 
 # Register the app
 su - omero -c "OMERO.server/bin/omero config append omero.web.apps '\"autotag\"'"
@@ -69,17 +71,23 @@ su - omero -c "OMERO.server/bin/omero config append omero.web.ui.center_plugins 
 su - omero -c "OMERO.server/bin/omero config append omero.web.ui.top_links '[\"Tag Search\", \"tagsearch\"]'"
 
 # Web gallery
+NAME_GALLERY_ZIP=${URL_GALLERY##*/}
+
 wget $URL_GALLERY
 unzip -q $NAME_GALLERY_ZIP
 
-mv $NAME_GALLERY OMERO.server/lib/python/omeroweb/gallery
+rm $NAME_GALLERY_ZIP
+mv gallery* OMERO.server/lib/python/omeroweb/gallery
 su - omero -c "OMERO.server/bin/omero config append omero.web.apps '\"gallery\"'"
 
 # Web test
+NAME_WEBTEST_ZIP=${URL_WEBTEST##*/}
+
 wget $URL_WEBTEST
 unzip -q $NAME_WEBTEST_ZIP
+rm $NAME_WEBTEST_ZIP
 
-mv $NAME_WEBTEST OMERO.server/lib/python/omeroweb/webtest
+mv webtest* OMERO.server/lib/python/omeroweb/webtest
 su - omero -c "OMERO.server/bin/omero config append omero.web.apps '\"webtest\"'"
 
 su - omero -c "OMERO.server/bin/omero config append omero.web.ui.right_plugins '[\"ROIs\", \"webtest/webclient_plugins/right_plugin.rois.js.html\", \"image_roi_tab\"]'"

--- a/linux/step05_1_all_webapps.sh
+++ b/linux/step05_1_all_webapps.sh
@@ -1,6 +1,8 @@
 
 #!/bin/bash
 
+PY_ENV=${PY_ENV:-all}
+
 # Figure details
 URL_FIGURE=http://downloads.openmicroscopy.org/figure/1.2.0/figure-1.2.0.zip
 NAME_FIGURE=figure-1.2.0
@@ -19,23 +21,21 @@ URL_WEBTEST=https://github.com/openmicroscopy/webtest/archive/master.zip
 NAME_WEBTEST_ZIP=master.zip
 NAME_WEBTEST=webtest-master
 
-# Read parameter
-VIRTUALENV=false
-for arg in "$@"; do
-	case "$arg" in ve)
-	VIRTUALENV=true;;
-	esac
-done
-
 # Add OMERO.figure
 cd ~omero
 wget $URL_FIGURE
 unzip -q $NAME_FIGURE.zip
 mv $NAME_FIGURE OMERO.server/lib/python/omeroweb/figure
 
+echo "value=$PY_ENV"
 # Install required packages
-if [ $VIRTUALENV = true ]; then
+if [ "$PY_ENV" = "ius" ]; then
 	/home/omero/omeroenv/bin/pip2.7 install reportlab markdown
+elif [ "$PY_ENV" = "scl" ]; then
+	set +u
+	source /opt/rh/python27/enable
+	set -u
+	pip install reportlab markdown
 else
 	pip install reportlab markdown
 fi

--- a/linux/step05_1_all_webapps.sh
+++ b/linux/step05_1_all_webapps.sh
@@ -37,6 +37,13 @@ elif [ "$PY_ENV" = "py27_scl" ]; then
 	source /opt/rh/python27/enable
 	set -u
 	pip install reportlab markdown
+elif [ "$PY_ENV" = "py27_ius" ]; then
+	virtualenv -p /usr/bin/python2.7 /home/omero/omeroenv
+	set +u
+	source /home/omero/omeroenv/bin/activate
+	set -u
+	/home/omero/omeroenv/bin/pip2.7 install reportlab markdown
+	deactivate
 else
 	pip install reportlab markdown
 fi

--- a/linux/step05_1_all_webapps.sh
+++ b/linux/step05_1_all_webapps.sh
@@ -14,6 +14,11 @@ URL_GALLERY=https://github.com/ome/gallery/archive/v1.0.0.zip
 NAME_GALLERY_ZIP=v1.0.0.zip
 NAME_GALLERY=gallery-1.0.0
 
+# web test
+URL_WEBTEST=https://github.com/openmicroscopy/webtest/archive/master.zip
+NAME_WEBTEST_ZIP=master.zip
+NAME_WEBTEST=webtest-master
+
 # Read parameter
 VIRTUALENV=false
 for arg in "$@"; do
@@ -52,9 +57,23 @@ su - omero -c "OMERO.server/bin/omero config append omero.web.ui.center_plugins 
 su - omero -c "OMERO.server/bin/omero config append omero.web.ui.top_links '[\"Tag Search\", \"tagsearch\"]'"
 
 # Web gallery
-#clone the repository
 wget $URL_GALLERY
 unzip -q $NAME_GALLERY_ZIP
 
 mv $NAME_GALLERY OMERO.server/lib/python/omeroweb/gallery
 su - omero -c "OMERO.server/bin/omero config append omero.web.apps '\"gallery\"'"
+
+# Web test
+wget $URL_WEBTEST
+unzip -q $NAME_WEBTEST_ZIP
+
+mv $NAME_WEBTEST OMERO.server/lib/python/omeroweb/webtest
+su - omero -c "OMERO.server/bin/omero config append omero.web.apps '\"webtest\"'"
+
+su - omero -c "OMERO.server/bin/omero config append omero.web.ui.right_plugins '[\"ROIs\", \"webtest/webclient_plugins/right_plugin.rois.js.html\", \"image_roi_tab\"]'"
+su - omero -c "OMERO.server/bin/omero config append omero.web.ui.center_plugins '[\"Split View\", \"webtest/webclient_plugins/center_plugin.splitview.js.html\", \"split_view_panel\"]'"
+
+
+
+
+

--- a/linux/test/centos6_apache22/Dockerfile
+++ b/linux/test/centos6_apache22/Dockerfile
@@ -17,7 +17,7 @@ ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	WEBAPPS=${WEBAPPS} bash install_centos6_apache22.sh && \
+	bash install_centos6_apache22.sh && \
 	bash docker_shutdown_centos6.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/centos6_apache22/Dockerfile
+++ b/linux/test/centos6_apache22/Dockerfile
@@ -3,6 +3,8 @@
 FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
+ARG WEBAPPS=false
+
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network
 
@@ -15,7 +17,7 @@ ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	bash install_centos6_apache22.sh && \
+	WEBAPPS=${WEBAPPS} bash install_centos6_apache22.sh && \
 	bash docker_shutdown_centos6.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/centos6_nginx/Dockerfile
+++ b/linux/test/centos6_nginx/Dockerfile
@@ -17,7 +17,7 @@ ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	WEBAPPS=${WEBAPPS} bash install_centos6_nginx.sh && \
+	bash install_centos6_nginx.sh && \
 	bash docker_shutdown_centos6.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/centos6_nginx/Dockerfile
+++ b/linux/test/centos6_nginx/Dockerfile
@@ -3,6 +3,8 @@
 FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
+ARG WEBAPPS=false
+
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network
 
@@ -15,7 +17,7 @@ ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	bash install_centos6_nginx.sh && \
+	WEBAPPS=${WEBAPPS} bash install_centos6_nginx.sh && \
 	bash docker_shutdown_centos6.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/centos6_py27_apache24/Dockerfile
+++ b/linux/test/centos6_py27_apache24/Dockerfile
@@ -3,6 +3,9 @@
 FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
+
+ARG WEBAPPS=false
+
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network
 
@@ -15,7 +18,7 @@ ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	bash install_centos6_py27_apache24.sh && \
+	WEBAPPS=${WEBAPPS} bash install_centos6_py27_apache24.sh && \
 	bash docker_shutdown_centos6.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/centos6_py27_apache24/Dockerfile
+++ b/linux/test/centos6_py27_apache24/Dockerfile
@@ -18,7 +18,7 @@ ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	WEBAPPS=${WEBAPPS} bash install_centos6_py27_apache24.sh && \
+	bash install_centos6_py27_apache24.sh && \
 	bash docker_shutdown_centos6.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/centos6_py27_ius_apache22/Dockerfile
+++ b/linux/test/centos6_py27_ius_apache22/Dockerfile
@@ -3,6 +3,8 @@
 FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
+ARG WEBAPPS=false
+
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network
 

--- a/linux/test/centos6_py27_ius_apache24/Dockerfile
+++ b/linux/test/centos6_py27_ius_apache24/Dockerfile
@@ -3,6 +3,8 @@
 FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
+ARG WEBAPPS=false
+
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network
 
@@ -15,7 +17,7 @@ ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	bash install_centos6_py27_ius_apache24.sh && \
+	WEBAPPS=${WEBAPPS} bash install_centos6_py27_ius_apache24.sh && \
 	bash docker_shutdown_centos6.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/centos6_py27_ius_apache24/Dockerfile
+++ b/linux/test/centos6_py27_ius_apache24/Dockerfile
@@ -17,7 +17,7 @@ ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	WEBAPPS=${WEBAPPS} bash install_centos6_py27_ius_apache24.sh && \
+	bash install_centos6_py27_ius_apache24.sh && \
 	bash docker_shutdown_centos6.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/centos6_py27_ius_nginx/Dockerfile
+++ b/linux/test/centos6_py27_ius_nginx/Dockerfile
@@ -3,6 +3,9 @@
 FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
+
+ARG WEBAPPS=false
+
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network
 

--- a/linux/test/centos6_py27_ius_nginx/Dockerfile
+++ b/linux/test/centos6_py27_ius_nginx/Dockerfile
@@ -18,7 +18,7 @@ ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	bash install_centos6_py27_ius_nginx.sh && \
+	WEBAPPS=${WEBAPPS} bash install_centos6_py27_ius_nginx.sh && \
 	bash docker_shutdown_centos6.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/centos6_py27_ius_nginx/Dockerfile
+++ b/linux/test/centos6_py27_ius_nginx/Dockerfile
@@ -18,7 +18,7 @@ ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	WEBAPPS=${WEBAPPS} bash install_centos6_py27_ius_nginx.sh && \
+	bash install_centos6_py27_ius_nginx.sh && \
 	bash docker_shutdown_centos6.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/centos6_py27_nginx/Dockerfile
+++ b/linux/test/centos6_py27_nginx/Dockerfile
@@ -3,6 +3,9 @@
 FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
+
+ARG WEBAPPS=false
+
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network
 
@@ -15,7 +18,7 @@ ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	bash install_centos6_py27_nginx.sh && \
+	WEBAPPS=${WEBAPPS} bash install_centos6_py27_nginx.sh && \
 	bash docker_shutdown_centos6.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/centos6_py27_nginx/Dockerfile
+++ b/linux/test/centos6_py27_nginx/Dockerfile
@@ -18,7 +18,7 @@ ADD omero-install-test.zip /
 RUN yum -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	WEBAPPS=${WEBAPPS} bash install_centos6_py27_nginx.sh && \
+	bash install_centos6_py27_nginx.sh && \
 	bash docker_shutdown_centos6.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/debian8_apache24/Dockerfile
+++ b/linux/test/debian8_apache24/Dockerfile
@@ -12,7 +12,7 @@ ADD omero-install-test.zip /
 RUN apt-get -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	WEBAPPS=${WEBAPPS} bash install_debian8_apache24.sh && \
+	bash install_debian8_apache24.sh && \
 	bash docker_shutdown_ubuntu1404.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/debian8_apache24/Dockerfile
+++ b/linux/test/debian8_apache24/Dockerfile
@@ -3,6 +3,8 @@
 FROM debian:jessie
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
+ARG WEBAPPS=false
+
 RUN apt-get update && apt-get -y install locales
 RUN update-locale LANG=C.UTF-8
 
@@ -10,7 +12,7 @@ ADD omero-install-test.zip /
 RUN apt-get -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	bash install_debian8_apache24.sh && \
+	WEBAPPS=${WEBAPPS} bash install_debian8_apache24.sh && \
 	bash docker_shutdown_ubuntu1404.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/debian8_nginx/Dockerfile
+++ b/linux/test/debian8_nginx/Dockerfile
@@ -3,6 +3,8 @@
 FROM debian:jessie
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
+ARG WEBAPPS=false
+
 RUN apt-get update && apt-get -y install locales
 RUN update-locale LANG=C.UTF-8
 
@@ -10,7 +12,7 @@ ADD omero-install-test.zip /
 RUN apt-get -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	bash install_debian8_nginx.sh && \
+	WEBAPPS=${WEBAPPS} bash install_debian8_nginx.sh && \
 	bash docker_shutdown_ubuntu1404.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/debian8_nginx/Dockerfile
+++ b/linux/test/debian8_nginx/Dockerfile
@@ -12,7 +12,7 @@ ADD omero-install-test.zip /
 RUN apt-get -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	WEBAPPS=${WEBAPPS} bash install_debian8_nginx.sh && \
+	bash install_debian8_nginx.sh && \
 	bash docker_shutdown_ubuntu1404.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/docker-build.sh
+++ b/linux/test/docker-build.sh
@@ -17,6 +17,10 @@ rm -rf omero-install-test
 
 IMAGE=omero_install_test_${1%*/}
 echo "Building image $IMAGE"
-docker build -t $IMAGE --no-cache --build-arg WEBAPPS=${WEBAPPS} $1
-echo "Test this image by running docker run -it [...] $IMAGE"
 
+if [[ $1 =~ "centos7" ]]; then
+	docker build -t $IMAGE --no-cache $1
+else
+	docker build -t $IMAGE --no-cache --build-arg WEBAPPS=${WEBAPPS} $1
+fi
+echo "Test this image by running docker run -it [...] $IMAGE"

--- a/linux/test/docker-build.sh
+++ b/linux/test/docker-build.sh
@@ -5,6 +5,8 @@ if [ $# -ne 1 ]; then
 	exit 2
 fi
 
+WEBAPPS=${WEBAPPS:-false}
+
 set -e
 
 rm -rf omero-install-test
@@ -15,6 +17,6 @@ rm -rf omero-install-test
 
 IMAGE=omero_install_test_${1%*/}
 echo "Building image $IMAGE"
-docker build -t $IMAGE --no-cache $1
+docker build -t $IMAGE --no-cache --build-arg WEBAPPS=${WEBAPPS} $1
 echo "Test this image by running docker run -it [...] $IMAGE"
 

--- a/linux/test/ubuntu1404_apache24/Dockerfile
+++ b/linux/test/ubuntu1404_apache24/Dockerfile
@@ -3,13 +3,15 @@
 FROM ubuntu:14.04
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
+ARG WEBAPPS=false
+
 RUN update-locale LANG=C.UTF-8
 
 ADD omero-install-test.zip /
 RUN apt-get update && apt-get -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	bash install_ubuntu1404_apache24.sh && \
+	WEBAPPS=${WEBAPPS} bash install_ubuntu1404_apache24.sh && \
 	bash docker_shutdown_ubuntu1404.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/ubuntu1404_apache24/Dockerfile
+++ b/linux/test/ubuntu1404_apache24/Dockerfile
@@ -11,7 +11,7 @@ ADD omero-install-test.zip /
 RUN apt-get update && apt-get -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	WEBAPPS=${WEBAPPS} bash install_ubuntu1404_apache24.sh && \
+	bash install_ubuntu1404_apache24.sh && \
 	bash docker_shutdown_ubuntu1404.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/ubuntu1404_nginx/Dockerfile
+++ b/linux/test/ubuntu1404_nginx/Dockerfile
@@ -11,7 +11,7 @@ ADD omero-install-test.zip /
 RUN apt-get update && apt-get -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	WEBAPPS=${WEBAPPS} bash install_ubuntu1404_nginx.sh && \
+	bash install_ubuntu1404_nginx.sh && \
 	bash docker_shutdown_ubuntu1404.sh
 ADD run.sh /home/omero/run.sh
 

--- a/linux/test/ubuntu1404_nginx/Dockerfile
+++ b/linux/test/ubuntu1404_nginx/Dockerfile
@@ -3,13 +3,15 @@
 FROM ubuntu:14.04
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
+ARG WEBAPPS=false
+
 RUN update-locale LANG=C.UTF-8
 
 ADD omero-install-test.zip /
 RUN apt-get update && apt-get -y install unzip && unzip omero-install-test.zip
 
 RUN cd omero-install-test && \
-	bash install_ubuntu1404_nginx.sh && \
+	WEBAPPS=${WEBAPPS} bash install_ubuntu1404_nginx.sh && \
 	bash docker_shutdown_ubuntu1404.sh
 ADD run.sh /home/omero/run.sh
 


### PR DESCRIPTION
Allow to build with and without web applications (figure, webtagging, gallery and webtest)
This is currently limited to ubuntu, centos6, centos6-scl, debian8, centos7
in the test directory
To build w/o web apps run one of the following commands:
- `./docker-build.sh ubuntu1404_nginx/` or `./docker-build.sh ubuntu1404_apache24/`
- `./docker-build.sh centos6_nginx/` or `./docker-build.sh centos6_apache22/`
- `./docker-build.sh centos6_py27_nginx/` or `./docker-build.sh centos6_py27_apache24/`
- `./docker-build.sh debian8_nginx/` or `WEBAPPS=true ./docker-build.sh debian8_apache24/`

To build with web apps run one of the following commands:
- `WEBAPPS=true ./docker-build.sh ubuntu1404_nginx/` or `WEBAPPS=true ./docker-build.sh ubuntu1404_apache24/`
- `WEBAPPS=true ./docker-build.sh centos6_nginx/` or `WEBAPPS=true ./docker-build.sh centos6_apache22/`
- `WEBAPPS=true ./docker-build.sh centos6_py27_nginx/` or `WEBAPPS=true ./docker-build.sh centos6_py27_apache24/`
- `WEBAPPS=true ./docker-build.sh debian8_nginx/` or `WEBAPPS=true ./docker-build.sh debian8_apache24/`
- Check that the applications are installed:
   For example, run
  `docker run --rm -it -p 8080:80 -p 4063:4063 -p 4064:4064 omero_install_test_ubuntu1404_nginx`
  after running `WEBAPPS=true ./docker-build.sh ubuntu1404_nginx/`

To test centos7, run:
- `./docker-build.sh centos7/`
- `CID=$(docker run -d -p 2222:22 -p 4063:4063 -p 4064:4064 -p 8080:80 --privileged omero_install_test_centos7)`
- `ssh -o UserKnownHostsFile=/dev/null root@<address of container>  -p 2222` (password omero)
- when logged in, `cd /omero-install-test`
- then `WEBAPPS=true bash install_centos7_nginx` (or `install_centos7_apache24.sh`) to install the web apps 

If we are happy with the approach, we can do the same for `OMEROVER` (in a follow-up PR)
