### PR TITLE
Parameters

### DIFF
--- a/linux/install_centos6_apache22.sh
+++ b/linux/install_centos6_apache22.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-OMEROVER=omero
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env

--- a/linux/install_centos6_nginx.sh
+++ b/linux/install_centos6_nginx.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-OMEROVER=omero
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env

--- a/linux/install_centos6_py27_apache24.sh
+++ b/linux/install_centos6_py27_apache24.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-OMEROVER=omero
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env

--- a/linux/install_centos6_py27_ius_apache22.sh
+++ b/linux/install_centos6_py27_ius_apache22.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-OMEROVER=omero
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env

--- a/linux/install_centos6_py27_ius_apache24.sh
+++ b/linux/install_centos6_py27_ius_apache24.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-OMEROVER=omero
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env

--- a/linux/install_centos6_py27_ius_nginx.sh
+++ b/linux/install_centos6_py27_ius_nginx.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-OMEROVER=omero
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env

--- a/linux/install_centos6_py27_nginx.sh
+++ b/linux/install_centos6_py27_nginx.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-OMEROVER=omero
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env

--- a/linux/install_centos7_apache24.sh
+++ b/linux/install_centos7_apache24.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-OMEROVER=omero
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env

--- a/linux/install_centos7_nginx.sh
+++ b/linux/install_centos7_nginx.sh
@@ -12,7 +12,7 @@ bash -eux step01_centos7_deps.sh
 bash -eux step02_all_setup.sh
 bash -eux step03_all_postgres.sh
 
-cp settings.env step04_all_omero.sh ~omero
+cp settings.env step04_all_$OMEROVER.sh ~omero
 su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
 bash -eux step05_centos7_nginx.sh

--- a/linux/install_centos7_nginx.sh
+++ b/linux/install_centos7_nginx.sh
@@ -2,6 +2,7 @@
 
 set -e -u -x
 
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env
@@ -12,7 +13,7 @@ bash -eux step02_all_setup.sh
 bash -eux step03_all_postgres.sh
 
 cp settings.env step04_all_omero.sh ~omero
-su - omero -c "bash -eux step04_all_omero.sh"
+su - omero -c "bash -eux step04_all_$OMEROVER.sh"
 
 bash -eux step05_centos7_nginx.sh
 

--- a/linux/install_debian8_apache24.sh
+++ b/linux/install_debian8_apache24.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-OMEROVER=omero
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env

--- a/linux/install_debian8_nginx.sh
+++ b/linux/install_debian8_nginx.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-OMEROVER=omero
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env

--- a/linux/install_ubuntu1404_apache24.sh
+++ b/linux/install_ubuntu1404_apache24.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-OMEROVER=omero
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env

--- a/linux/install_ubuntu1404_nginx.sh
+++ b/linux/install_ubuntu1404_nginx.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-OMEROVER=omero
+OMEROVER=${OMEROVER:-omero}
 WEBAPPS=${WEBAPPS:-false}
 
 source settings.env

--- a/linux/step01_centos6_deps.sh
+++ b/linux/step01_centos6_deps.sh
@@ -5,11 +5,15 @@ yum -y install epel-release
 curl -o /etc/yum.repos.d/zeroc-ice-el6.repo \
 	http://download.zeroc.com/Ice/3.5/el6/zeroc-ice-el6.repo
 
+
 yum -y install \
 	unzip \
-	wget \
-	java-1.7.0-openjdk \
-	ice ice-python ice-servers
+	wget
+
+#install java
+bash -eux step01_centos_java_deps.sh
+
+yum -y install ice ice-python ice-servers
 
 yum -y install \
 	python-pip python-devel python-virtualenv \

--- a/linux/step01_centos6_py27_deps.sh
+++ b/linux/step01_centos6_py27_deps.sh
@@ -11,8 +11,10 @@ yum -y install \
 	wget \
 	tar
 
+#install java
+bash -eux step01_centos_java_deps.sh
+
 yum -y install \
-	java-1.8.0-openjdk \
 	db53 db53-utils mcpp
 
 yum -y install \

--- a/linux/step01_centos6_py27_ius_deps.sh
+++ b/linux/step01_centos6_py27_ius_deps.sh
@@ -11,8 +11,10 @@ yum -y install \
 	wget \
 	tar
 
+#install java
+bash -eux step01_centos_java_deps.sh
+
 yum -y install \
-	java-1.8.0-openjdk \
 	db53 db53-utils mcpp
 
 yum -y install \

--- a/linux/step01_centos7_deps.sh
+++ b/linux/step01_centos7_deps.sh
@@ -7,8 +7,12 @@ curl -o /etc/yum.repos.d/zeroc-ice-el7.repo \
 
 yum -y install \
 	unzip \
-	wget \
-	java-1.8.0-openjdk \
+	wget
+
+#install java
+bash -eux step01_centos_java_deps.sh
+
+yum -y install \
 	ice ice-python ice-servers
 
 yum -y install \

--- a/linux/step01_centos_java_deps.sh
+++ b/linux/step01_centos_java_deps.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+JAVAVER=${JAVAVER:-open17}
+
+# Java installation default Java openjdk 1.7
+if [ "$JAVAVER" = "open18" ]; then
+	yum -y install java-1.8.0-openjdk
+elif [ "$JAVAVER" = "oracle17" ]; then
+	wget --no-cookies \
+	--no-check-certificate \
+	--header "Cookie: oraclelicense=accept-securebackup-cookie" \
+	"http://download.oracle.com/otn-pub/java/jdk/7u55-b13/jdk-7u55-linux-x64.rpm" \
+	-O jdk-7-linux-x64.rpm
+	yum -y localinstall jdk-7-linux-x64.rpm
+elif [ "$JAVAVER" = "oracle18" ]; then
+	wget --no-cookies \
+	--no-check-certificate \
+	--header "Cookie: oraclelicense=accept-securebackup-cookie" \
+	"http://download.oracle.com/otn-pub/java/jdk/8u65-b17/jdk-8u65-linux-x64.rpm" \
+	-O jdk-8-linux-x64.rpm
+	yum -y localinstall jdk-8-linux-x64.rpm
+else
+	yum -y install java-1.7.0-openjdk
+fi

--- a/linux/step01_debian8_deps.sh
+++ b/linux/step01_debian8_deps.sh
@@ -3,9 +3,34 @@
 apt-get update
 apt-get -y install \
 	unzip \
-	wget \
-	python-{matplotlib,numpy,pip,scipy,tables,virtualenv} \
-	openjdk-7-jre-headless \
+	wget
+
+#install java
+if [ "$JAVAVER" = "open18" ]; then
+	echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
+	apt-get -y install openjdk-8-jre-headless
+elif [ "$JAVAVER" = "oracle17" ]; then
+	echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" > /etc/apt/sources.list.d/webupd8team-java.list
+	echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list.d/webupd8team-java.list
+	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886
+	apt-get update
+	echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+	apt-get -y install oracle-java7-installer
+elif [ "$JAVAVER" = "oracle18" ]; then
+	echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" > /etc/apt/sources.list.d/webupd8team-java.list
+	echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list.d/webupd8team-java.list
+	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886
+	apt-get update
+	echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+	apt-get -y install oracle-java8-installer
+else
+	apt-get -y install openjdk-7-jre-headless
+fi
+
+apt-get -y install \
+	python-{matplotlib,numpy,pip,scipy,tables,virtualenv}
+
+apt-get -y install \
 	ice-services python-zeroc-ice \
 	postgresql
 

--- a/linux/step01_debian8_deps.sh
+++ b/linux/step01_debian8_deps.sh
@@ -8,7 +8,8 @@ apt-get -y install \
 #install java
 if [ "$JAVAVER" = "open18" ]; then
 	echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
-	apt-get -y install openjdk-8-jre-headless
+	apt-get update
+	apt-get -y install openjdk-8-jre-headless=8u66-b17-1~bpo8+1 ca-certificates-java=20140324
 elif [ "$JAVAVER" = "oracle17" ]; then
 	echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" > /etc/apt/sources.list.d/webupd8team-java.list
 	echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list.d/webupd8team-java.list

--- a/linux/step01_ubuntu1404_deps.sh
+++ b/linux/step01_ubuntu1404_deps.sh
@@ -1,11 +1,37 @@
 #!/bin/bash
+JAVAVER=${JAVAVER:-open17}
 
 apt-get update
 apt-get -y install \
 	unzip \
 	wget \
-	python-{matplotlib,numpy,pip,scipy,tables,virtualenv} \
-	openjdk-7-jre-headless \
+	python-{matplotlib,numpy,pip,scipy,tables,virtualenv}
+
+#install java
+if [ "$JAVAVER" = "open18" ]; then
+	apt-get -y install software-properties-common
+	add-apt-repository -y ppa:openjdk-r/ppa
+	apt-get update
+	apt-get -y install openjdk-8-jre
+elif [ "$JAVAVER" = "oracle17" ]; then
+	apt-get -y install software-properties-common
+	add-apt-repository -y ppa:webupd8team/java
+	apt-get update
+	echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
+	echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
+	apt-get -y install oracle-java7-installer
+elif [ "$JAVAVER" = "oracle18" ]; then
+	apt-get -y install software-properties-common
+	add-apt-repository -y ppa:webupd8team/java
+	apt-get update
+	echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
+	echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
+	apt-get -y install oracle-java8-installer
+else
+	apt-get -y install openjdk-7-jre-headless
+fi
+
+apt-get -y install \
 	ice-services python-zeroc-ice \
 	postgresql
 

--- a/linux/step03_centos6_py27_ius_virtualenv_deps.sh
+++ b/linux/step03_centos6_py27_ius_virtualenv_deps.sh
@@ -4,7 +4,7 @@ OMEROVER=${OMEROVER:-omero}
 
 # Install the OMERO dependencies in a virtual environment
 # Create virtual env.
-# -p only require if it has been installed with 2.6
+# -p only require if it has been installed with python 2.6
 
 virtualenv -p /usr/bin/python2.7 /home/omero/omeroenv
 set +u
@@ -21,7 +21,7 @@ set -u
 # Django
 /home/omero/omeroenv/bin/pip2.7 install "Django>=1.8,<1.9"
 
-if [ $OMEROVER = omerodev ]; then
+if [ $OMEROVER = omerodev ] || [ $OMEROVER = omeromerge ] ; then
 	/home/omero/omeroenv/bin/pip2.7 install omego
 fi
 

--- a/linux/step04_all_omeromerge.sh
+++ b/linux/step04_all_omeromerge.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e -u -x
+
+source settings.env
+
+virtualenv omego
+omego/bin/pip install omego
+
+BRANCH=OMERO-DEV-merge-build
+
+omego/bin/omego download --branch $BRANCH server
+ln -s OMERO.server-*/ OMERO.server
+
+OMERO.server/bin/omero config set omero.data.dir "$OMERO_DATA_DIR"
+OMERO.server/bin/omero config set omero.db.name "$OMERO_DB_NAME"
+OMERO.server/bin/omero config set omero.db.user "$OMERO_DB_USER"
+OMERO.server/bin/omero config set omero.db.pass "$OMERO_DB_PASS"
+OMERO.server/bin/omero db script -f OMERO.server/db.sql --password "$OMERO_ROOT_PASS"
+
+psql -h localhost -U "$OMERO_DB_USER" "$OMERO_DB_NAME" < OMERO.server/db.sql
+
+OMERO.server/bin/omero web config nginx --http "$OMERO_WEB_PORT" > OMERO.server/nginx.conf.tmp

--- a/linux/step04_centos6_py27_ius_omeromerge.sh
+++ b/linux/step04_centos6_py27_ius_omeromerge.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e -u -x
+
+source settings.env
+
+BRANCH=OMERO-DEV-merge-build
+
+/home/omero/omeroenv/bin/omego download --branch $BRANCH server
+ln -s OMERO.server-*/ OMERO.server
+
+OMERO.server/bin/omero config set omero.data.dir "$OMERO_DATA_DIR"
+OMERO.server/bin/omero config set omero.db.name "$OMERO_DB_NAME"
+OMERO.server/bin/omero config set omero.db.user "$OMERO_DB_USER"
+OMERO.server/bin/omero config set omero.db.pass "$OMERO_DB_PASS"
+OMERO.server/bin/omero db script -f OMERO.server/db.sql --password "$OMERO_ROOT_PASS"
+
+psql -h localhost -U "$OMERO_DB_USER" "$OMERO_DB_NAME" < OMERO.server/db.sql
+
+# This is the default in 5.2 so could be left unset
+OMERO.server/bin/omero config set omero.web.application_server wsgi-tcp
+OMERO.server/bin/omero web config nginx --http "$OMERO_WEB_PORT" > OMERO.server/nginx.conf.tmp

--- a/linux/step04_centos6_py27_omeromerge.sh
+++ b/linux/step04_centos6_py27_omeromerge.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e -u -x
+
+source settings.env
+
+set +u
+source /opt/rh/python27/enable
+set -u
+
+virtualenv omego
+omego/bin/pip install omego
+
+BRANCH=OMERO-DEV-merge-build
+
+omego/bin/omego download --branch $BRANCH server
+ln -s OMERO.server-*/ OMERO.server
+
+OMERO.server/bin/omero config set omero.data.dir "$OMERO_DATA_DIR"
+OMERO.server/bin/omero config set omero.db.name "$OMERO_DB_NAME"
+OMERO.server/bin/omero config set omero.db.user "$OMERO_DB_USER"
+OMERO.server/bin/omero config set omero.db.pass "$OMERO_DB_PASS"
+OMERO.server/bin/omero db script -f OMERO.server/db.sql --password "$OMERO_ROOT_PASS"
+
+psql -h localhost -U "$OMERO_DB_USER" "$OMERO_DB_NAME" < OMERO.server/db.sql
+
+OMERO.server/bin/omero web config nginx --http "$OMERO_WEB_PORT" > OMERO.server/nginx.conf.tmp

--- a/linux/test/centos6_apache22/Dockerfile
+++ b/linux/test/centos6_apache22/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
 ARG OMEROVER=omero
+ARG JAVAVER=open17
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_apache22/Dockerfile
+++ b/linux/test/centos6_apache22/Dockerfile
@@ -4,6 +4,7 @@ FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
+ARG OMEROVER=omero
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_nginx/Dockerfile
+++ b/linux/test/centos6_nginx/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
 ARG OMEROVER=omero
+ARG JAVAVER=open17
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_nginx/Dockerfile
+++ b/linux/test/centos6_nginx/Dockerfile
@@ -4,6 +4,7 @@ FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
+ARG OMEROVER=omero
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_py27_apache24/Dockerfile
+++ b/linux/test/centos6_py27_apache24/Dockerfile
@@ -3,8 +3,8 @@
 FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-
 ARG WEBAPPS=false
+ARG OMEROVER=omero
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_py27_apache24/Dockerfile
+++ b/linux/test/centos6_py27_apache24/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
 ARG OMEROVER=omero
+ARG JAVAVER=open17
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_py27_ius_apache22/Dockerfile
+++ b/linux/test/centos6_py27_ius_apache22/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
 ARG OMEROVER=omero
+ARG JAVAVER=open17
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_py27_ius_apache22/Dockerfile
+++ b/linux/test/centos6_py27_ius_apache22/Dockerfile
@@ -4,6 +4,7 @@ FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
+ARG OMEROVER=omero
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_py27_ius_apache24/Dockerfile
+++ b/linux/test/centos6_py27_ius_apache24/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
 ARG OMEROVER=omero
+ARG JAVAVER=open17
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_py27_ius_apache24/Dockerfile
+++ b/linux/test/centos6_py27_ius_apache24/Dockerfile
@@ -4,6 +4,7 @@ FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
+ARG OMEROVER=omero
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_py27_ius_nginx/Dockerfile
+++ b/linux/test/centos6_py27_ius_nginx/Dockerfile
@@ -3,8 +3,8 @@
 FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-
 ARG WEBAPPS=false
+ARG OMEROVER=omero
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_py27_ius_nginx/Dockerfile
+++ b/linux/test/centos6_py27_ius_nginx/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
 ARG OMEROVER=omero
+ARG JAVAVER=open17
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_py27_nginx/Dockerfile
+++ b/linux/test/centos6_py27_nginx/Dockerfile
@@ -3,8 +3,8 @@
 FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-
 ARG WEBAPPS=false
+ARG OMEROVER=omero
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/centos6_py27_nginx/Dockerfile
+++ b/linux/test/centos6_py27_nginx/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
 ARG OMEROVER=omero
+ARG JAVAVER=open17
 
 # Needed for postgres init.d
 RUN touch /etc/sysconfig/network

--- a/linux/test/debian8_apache24/Dockerfile
+++ b/linux/test/debian8_apache24/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
 ARG OMEROVER=omero
+ARG JAVAVER=open17
 
 RUN apt-get update && apt-get -y install locales
 RUN update-locale LANG=C.UTF-8

--- a/linux/test/debian8_apache24/Dockerfile
+++ b/linux/test/debian8_apache24/Dockerfile
@@ -4,6 +4,7 @@ FROM debian:jessie
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
+ARG OMEROVER=omero
 
 RUN apt-get update && apt-get -y install locales
 RUN update-locale LANG=C.UTF-8

--- a/linux/test/debian8_nginx/Dockerfile
+++ b/linux/test/debian8_nginx/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
 ARG OMEROVER=omero
+ARG JAVAVER=open17
 
 RUN apt-get update && apt-get -y install locales
 RUN update-locale LANG=C.UTF-8

--- a/linux/test/debian8_nginx/Dockerfile
+++ b/linux/test/debian8_nginx/Dockerfile
@@ -4,6 +4,7 @@ FROM debian:jessie
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
+ARG OMEROVER=omero
 
 RUN apt-get update && apt-get -y install locales
 RUN update-locale LANG=C.UTF-8

--- a/linux/test/docker-build.sh
+++ b/linux/test/docker-build.sh
@@ -6,6 +6,7 @@ if [ $# -ne 1 ]; then
 fi
 
 WEBAPPS=${WEBAPPS:-false}
+OMEROVER=${OMEROVER:-omero}
 
 set -e
 
@@ -21,6 +22,6 @@ echo "Building image $IMAGE"
 if [[ $1 =~ "centos7" ]]; then
 	docker build -t $IMAGE --no-cache $1
 else
-	docker build -t $IMAGE --no-cache --build-arg WEBAPPS=${WEBAPPS} $1
+	docker build -t $IMAGE --no-cache --build-arg OMEROVER=${OMEROVER} --build-arg WEBAPPS=${WEBAPPS} $1
 fi
 echo "Test this image by running docker run -it [...] $IMAGE"

--- a/linux/test/docker-build.sh
+++ b/linux/test/docker-build.sh
@@ -7,6 +7,7 @@ fi
 
 WEBAPPS=${WEBAPPS:-false}
 OMEROVER=${OMEROVER:-omero}
+JAVAVER=${JAVAVER:-open17}
 
 set -e
 
@@ -22,6 +23,7 @@ echo "Building image $IMAGE"
 if [[ $1 =~ "centos7" ]]; then
 	docker build -t $IMAGE --no-cache $1
 else
-	docker build -t $IMAGE --no-cache --build-arg OMEROVER=${OMEROVER} --build-arg WEBAPPS=${WEBAPPS} $1
+	docker build -t $IMAGE --no-cache --build-arg OMEROVER=${OMEROVER} \
+	--build-arg JAVAVER=${JAVAVER} --build-arg WEBAPPS=${WEBAPPS} $1
 fi
 echo "Test this image by running docker run -it [...] $IMAGE"

--- a/linux/test/ubuntu1404_apache24/Dockerfile
+++ b/linux/test/ubuntu1404_apache24/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
 ARG OMEROVER=omero
+ARG JAVAVER=open17
 
 RUN update-locale LANG=C.UTF-8
 

--- a/linux/test/ubuntu1404_apache24/Dockerfile
+++ b/linux/test/ubuntu1404_apache24/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:14.04
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
+ARG OMEROVER=omero
 
 RUN update-locale LANG=C.UTF-8
 

--- a/linux/test/ubuntu1404_nginx/Dockerfile
+++ b/linux/test/ubuntu1404_nginx/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
 ARG OMEROVER=omero
+ARG JAVAVER=open17
 
 RUN update-locale LANG=C.UTF-8
 

--- a/linux/test/ubuntu1404_nginx/Dockerfile
+++ b/linux/test/ubuntu1404_nginx/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:14.04
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG WEBAPPS=false
+ARG OMEROVER=omero
 
 RUN update-locale LANG=C.UTF-8
 


### PR DESCRIPTION
Add options to specify parameters OMEROVER and JAVAVER
to reduce manual testing, built via travis. See build number below
- commits 60c83a4 and 1433486 tested via travis
  - modified `.travis.yml` (commit reverted) to test `omerodev` specified i.e.  `cd linux/test && OMEROVER=omerodev ./docker-build.sh $ENV && docker run -d omero_install_test_$ENV` https://travis-ci.org/ome/omero-install/builds/102704491
  - no option specified travis  https://travis-ci.org/ome/omero-install/builds/102750274
- commits 7e04e37 and acebae9 tested via travis
  - modified `.travis.yml` (commit reverted) to test `omeromerge` specified
    i.e.  `cd linux/test && OMEROVER=omeromerge ./docker-build.sh $ENV && docker run -d omero_install_test_$ENV` build https://travis-ci.org/ome/omero-install/builds/102823058
- commits 061b747,  d8d40d6, f29d7e8, a422b0a default is set to openjdk 1.7
  - oracle java 1.8 i.e. `cd linux/test && JAVAVER=oracle18 ./docker-build.sh $ENV && docker run -d omero_install_test_$ENV` build https://travis-ci.org/ome/omero-install/builds/102969240
  - oracle java 1.7 i.e. `cd linux/test && JAVAVER=oracle17 ./docker-build.sh $ENV && docker run -d omero_install_test_$ENV` build https://travis-ci.org/ome/omero-install/builds/102984181
  - openjdk 1.8 i.e.  ``cd linux/test && JAVAVER=open18 ./docker-build.sh $ENV && docker run -d omero_install_test_$ENV` build https://travis-ci.org/ome/omero-install/builds/102991973

Manual testing: centos7 only

To test: 
- run `./docker-build.sh centos7/`
- `CID=$(docker run -d -p 2222:22 -p 8080:80 -p 4063:4063 -p 4064:4064 --privileged omero_install_test_centos7)`
  - `ssh -o UserKnownHostsFile=/dev/null root@<address of container> -p 2222`
  - `cd /omero-install-test`
  - Run for example `OMEROVER=omerodev JAVAVER=oracle17 bash install_centos7_nginx.sh`
    (no need to test all combinations)
