### PR TITLE
Pillow version

### DIFF
--- a/linux/step01_centos6_deps.sh
+++ b/linux/step01_centos6_deps.sh
@@ -22,7 +22,7 @@ yum -y install \
 	hdf5-devel
 
 # Requires gcc {libjpeg,libpng,libtiff,zlib}-devel
-pip install 'Pillow<3.0'
+pip install Pillow
 pip install numexpr==1.4.2
 # Requires gcc, Cython, hdf5-devel
 pip install tables==2.4.0

--- a/linux/step01_centos6_py27_deps.sh
+++ b/linux/step01_centos6_py27_deps.sh
@@ -38,8 +38,7 @@ easy_install pip
 export PYTHONWARNINGS="ignore:Unverified HTTPS request"
 pip install tables matplotlib
 
-# Cap Pillow version due to a limitation in OMERO.figure with v3.0.0
-pip install "Pillow<3.0"
+pip install Pillow
 
 # Django
 pip install "Django>=1.8,<1.9"

--- a/linux/step01_centos7_deps.sh
+++ b/linux/step01_centos7_deps.sh
@@ -24,8 +24,7 @@ yum -y install \
 	libjpeg-devel \
 	gcc
 
-# Cap Pillow version due to a limitation in OMERO.figure with v3.0.0
-pip install 'Pillow<3.0'
+pip install Pillow
 
 # Django
 pip install 'Django>=1.8,<1.9'

--- a/linux/step01_debian8_deps.sh
+++ b/linux/step01_debian8_deps.sh
@@ -20,7 +20,7 @@ apt-get -y install \
 	tcl8.6-dev \
 	tk8.6-dev
 
-pip install --upgrade "Pillow<3.0"
+pip install --upgrade Pillow
 
 # Django
 pip install "Django>=1.8,<1.9"

--- a/linux/step01_ubuntu1404_deps.sh
+++ b/linux/step01_ubuntu1404_deps.sh
@@ -20,7 +20,7 @@ apt-get -y install \
 	tcl8.6-dev \
 	tk8.6-dev
 
-pip install --upgrade "Pillow<3.0"
+pip install --upgrade Pillow
 
 # Django
 pip install "Django>=1.8,<1.9"

--- a/linux/step03_centos6_py27_ius_virtualenv_deps.sh
+++ b/linux/step03_centos6_py27_ius_virtualenv_deps.sh
@@ -12,8 +12,7 @@ source /home/omero/omeroenv/bin/activate
 set -u
 /home/omero/omeroenv/bin/pip install --upgrade pip
 
-# Cap Pillow version due to a limitation in OMERO.figure with v3.0.0
-/home/omero/omeroenv/bin/pip2.7 install "Pillow<3.0"
+/home/omero/omeroenv/bin/pip2.7 install Pillow
 
 # install omero dependencies
 /home/omero/omeroenv/bin/pip2.7 install numpy matplotlib


### PR DESCRIPTION
No longer cap Pillow version.
Version 3.1 will now be installed. No more issues when exporting in Figure

To test. Run for example
- `WEBAPPS=true ./docker-build.sh ubuntu1404_nginx/`
- Then `docker run --rm -it -p 8080:80 -p 4063:4063 -p 4064:4064 omero_install_test_ubuntu1404_nginx`
- Check that all the export methods in figure work.

cc @will-moore 
