### PR TITLE
Use ~/OMERO.data as data.dir for homebrew script

### DIFF
--- a/osx/step02_omero.sh
+++ b/osx/step02_omero.sh
@@ -6,7 +6,7 @@ set -u
 set -x
 
 export PATH=/usr/local/bin:$PATH
-export OMERO_DATA_DIR=${OMERO_DATA_DIR:-/tmp/var/OMERO.data}
+export OMERO_DATA_DIR=${OMERO_DATA_DIR:-~/OMERO.data}
 export PSQL_SCRIPT_NAME=${PSQL_SCRIPT_NAME:-OMERO.sql}
 export ROOT_PASSWORD=${ROOT_PASSWORD:-omero}
 export ICE=${ICE:-3.5}


### PR DESCRIPTION
As suggested https://github.com/openmicroscopy/ome-documentation/pull/1394#issuecomment-179870643 applying the same change here as made to the homebrew install docs.
