### PR TITLE
Re-add cluster initialization to the Homebrew installation script

### DIFF
--- a/osx/step02_omero.sh
+++ b/osx/step02_omero.sh
@@ -32,6 +32,9 @@ bash bin/omero_python_deps
 # Set additional environment variables
 export ICE_CONFIG=$(brew --prefix omero52)/etc/ice.config
 
+# Initialize the PostgreSQL cluster
+initdb -E UTF8 /usr/local/var/postgres
+
 # Start PostgreSQL
 pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
 


### PR DESCRIPTION
With https://github.com/Homebrew/homebrew/commit/19de04b5a2c049c35fb27b3f06aa30cf1924966e, the PostgreSQL cluster is no longer initialized at install. This commit should restore the OMERO installation via Homebrew.
