### PR TITLE
Docker installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 before_install:  
   - sudo apt-get update
-  - sudo apt-get install docker-engine
+  - sudo DEBIAN_FRONTEND=noninteractive apt-get -q -o Dpkg::Options::="--force-confnew" install -y docker-engine
 
 script:
     - cd linux/test && ./docker-build.sh $ENV && docker run -d omero_install_test_$ENV


### PR DESCRIPTION
Disable interactive when installing docker-engine
This should force the config to be overwritten
cf https://github.com/ome/ome-docker/pull/30
