### PR TITLE
Gunicorn version

### DIFF
--- a/linux/step05_centos6_nginx.sh
+++ b/linux/step05_centos6_nginx.sh
@@ -9,7 +9,7 @@ enabled=1
 EOF
 
 yum -y install nginx
-pip install gunicorn
+pip install "gunicorn>=19.3"
 
 # See setup_omero*.sh for the nginx config file creation
 

--- a/linux/step05_centos6_py27_ius_nginx.sh
+++ b/linux/step05_centos6_py27_ius_nginx.sh
@@ -18,7 +18,7 @@ set +u
 source /home/omero/omeroenv/bin/activate
 set -u
 # install in virtualenv created in step01
-/home/omero/omeroenv/bin/pip2.7 install --upgrade gunicorn
+/home/omero/omeroenv/bin/pip2.7 install --upgrade "gunicorn>=19.3"
 
 deactivate
 # See setup_omero*.sh for the nginx config file creation

--- a/linux/step05_centos6_py27_nginx.sh
+++ b/linux/step05_centos6_py27_nginx.sh
@@ -13,7 +13,7 @@ enabled=1
 EOF
 
 yum -y install nginx
-pip install gunicorn
+pip install "gunicorn>=19.3"
 
 # See setup_omero*.sh for the nginx config file creation
 

--- a/linux/step05_centos7_nginx.sh
+++ b/linux/step05_centos7_nginx.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-yum -y --enablerepo=cr install nginx python-gunicorn
+yum -y --enablerepo=cr install nginx
+
+pip install "gunicorn>=19.3"
 
 # See setup_omero*.sh for the nginx config file creation
 

--- a/linux/step05_ubuntu1404_nginx.sh
+++ b/linux/step05_ubuntu1404_nginx.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-apt-get -y install nginx gunicorn
+apt-get -y install nginx
+
+pip install "gunicorn>=19.3"
 
 # See setup_omero*.sh for the nginx config file creation
 


### PR DESCRIPTION
Set the minimum version for gunicorn
Also install gunicorn via pip on ubuntu and centos7

To test ubuntu change, run:
- `./docker-build.sh ubuntu1404_nginx/`
- `docker run --rm -it -p 8080:80 -p 4063:4063 -p 4064:4064 omero_install_test_ubuntu1404_nginx`

To test centos7 change, run:
- `./docker-build.sh centos7/`
- `CID=$(docker run -d -p 8080:80 -p 4063:4063 -p 4064:4064 -p 2222:22 --privileged omero_install_test_centos7)`
- `ssh -o UserKnownHostsFile=/dev/null root@<address of container> -p 2222` where `<address of container>` will be something like  `192.168.99.100`

The other changes only set the minimum version.
