### PR TITLE
Doc generate

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -24,3 +24,15 @@ there are separate scripts for Python 2.7, the default is Python 2.6.
 
 Usernames and passwords can be customized in `settings.env`.
 
+Documentation generation
+========================
+To generate a walkthrough file corresponding to a given OS, run the
+`autogenerate.sh` script, the OS is specified as a paramater e.g.
+	
+	OS=ubuntu1404 bash autogenerate.sh
+
+The walkthrough file is used for the omero documention e.g.
+http://www.openmicroscopy.org/site/support/omero5.2/sysadmins/unix/server-linux-walkthrough.html
+but it should not be executed.
+
+

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -89,12 +89,36 @@ if [ $OS = "debian8" ] ; then
 fi
 
 echo -en '\n' >> $file
-echo "#start-step05: Install Web server, Nginx, as root" >> $file
+echo "#start-step05: Install Web server as root" >> $file
+echo "#start-nginx" >> $file
 start=$(sed -n '/#start-install/=' step05_"$v"_nginx.sh)
 start=$((start+1))
 line=$(sed -n ''$start',$p' step05_"$v"_nginx.sh)
-
 echo "$line" >> $file
+echo "#end-nginx" >> $file
+echo -en '\n' >> $file
+echo "#start-apache" >> $file
+
+apachever="apache24" #webserver might become a parameter
+if [ $OS = "centos6" ] || [ $OS = "centos6_py27_ius" ] ; then
+	apachever="apache22"
+fi
+line=$(sed -n ''/#start-copy/','/#end-copy/'p' step05_"$v"_"$apachever".sh)
+echo "$line" >> $file
+echo "#start-configure: Configure OMERO.web as the omero system user" >> $file
+start=$(sed -n '/#start-config/=' setup_omero_"$apachever".sh)
+start=$((start+1))
+line=$(sed -n ''$start',$p' setup_omero_"$apachever".sh)
+echo "$line" >> $file
+echo "#end-configure" >> $file
+#start install
+echo "#start-apache-install" >> $file
+start=$(sed -n '/#start-install/=' step05_"$v"_"$apachever".sh)
+start=$((start+1))
+line=$(sed -n ''$start',$p' step05_"$v"_"$apachever".sh)
+echo "$line" >> $file
+echo "#end-apache-install" >> $file
+echo "#end-apache" >> $file
 echo "#end-step05" >> $file
 
 if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -43,7 +43,7 @@ if [ $OS = "centos6_py27_ius" ] ; then
 	number=$((number+1))
 	line=$(sed -n ''$number',$p' step03_"$OS"_virtualenv_deps.sh)
 	echo "$line" >> $file
-	echo "#end-step01.1:" >> $file
+	echo "#end-step01.1" >> $file
 fi
 
 echo -en '\n' >> $file
@@ -54,7 +54,7 @@ else
 	line=$(sed -n '2,$p' step02_all_setup.sh)
 fi
 echo "$line" >> $file
-echo "#end-step02:" >> $file
+echo "#end-step02" >> $file
 
 # postgres remove section
 echo -en '\n' >> $file

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -68,7 +68,7 @@ echo "#end-step03" >> $file
 
 echo -en '\n' >> $file
 echo "#start-step04: As the omero system user, install the OMERO.server" >> $file
-if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
+if [[ $OS =~ "centos6_py27" ]] ; then
 	var="${OS//_/}"
 	echo "#start-copy-omeroscript" >> $file
 	echo "cp settings.env omero-$var.env step04_$OS_omero.sh ~omero " >> $file
@@ -125,7 +125,7 @@ echo "#end-apache-install" >> $file
 echo "#end-apache" >> $file
 echo "#end-step05" >> $file
 
-if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
+if [[ $OS =~ "centos6" ]] ; then
 	v="centos6"
 fi
 

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -145,6 +145,13 @@ echo "#end-step07" >> $file
 
 echo -en '\n' >> $file
 echo "#start-step08: As root, perform regular tasks" >> $file
+echo "#start-omeroweb-cron" >> $file
+line=$(sed -n '2,$p' omero-web-cron)
+echo "$line" >> $file
+echo "#end-omeroweb-cron" >> $file
+echo "#Copy omero-web-cron into the appropriate location" >> $file
+echo "#start-copy-omeroweb-cron" >> $file
 line=$(sed -n '2,$p' step08_all_cron.sh)
 echo "$line" >> $file
+echo "#end-copy-omeroweb-cron" >> $file
 echo "#end-step08" >> $file

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -13,7 +13,7 @@ source settings.env
 EOF
 
 echo -en '\n' >> $file
-echo "#step 1: Install dependencies as root" >> $file
+echo "#start-step01: Install dependencies as root" >> $file
 if [ $OS = "centos7" ] ; then
 	number=$(sed -n '/#start-workaround/=' step01_"$OS"_deps.sh)
 	number=$((number-1))
@@ -26,12 +26,12 @@ else
 	line=$(sed -n '2,$p' step01_"$OS"_deps.sh)
 fi
 echo "$line" >> $file
-echo "#end step 1" >> $file
+echo "#end-step01" >> $file
 
 # review the name of the original file.
 if [ $OS = "centos6_py27_ius" ] ; then
 	echo -en '\n' >> $file
-	echo "#step 1.1: virtual env" >> $file
+	echo "#start-step01.1: virtual env" >> $file
 	#find from where to start copying
 	start=$(sed -n '/#start-install/=' step03_"$OS"_virtualenv_deps.sh)
 	start=$((start+1))
@@ -43,31 +43,31 @@ if [ $OS = "centos6_py27_ius" ] ; then
 	number=$((number+1))
 	line=$(sed -n ''$number',$p' step03_"$OS"_virtualenv_deps.sh)
 	echo "$line" >> $file
-	echo "#end step 1.1:" >> $file
+	echo "#end-step01.1:" >> $file
 fi
 
 echo -en '\n' >> $file
-echo "#step 2: Set-up as root" >> $file
+echo "#start-step02: Set-up as root" >> $file
 if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
 	line=$(sed -n '2,$p' step02_"$OS"_setup.sh)
 else 
 	line=$(sed -n '2,$p' step02_all_setup.sh)
 fi
 echo "$line" >> $file
-echo "#end step 2:" >> $file
+echo "#end-step02:" >> $file
 
 # postgres remove section
 echo -en '\n' >> $file
-echo "#step 3: Database user and database creation as root" >> $file
+echo "#start-step03: Database user and database creation as root" >> $file
 #find from where to start copying
 start=$(sed -n '/#start-setup/=' step03_all_postgres.sh)
 start=$((start+1))
 line=$(sed -n ''$start',$p' step03_all_postgres.sh)
 echo "$line" >> $file
-echo "#end step 3" >> $file
+echo "#end-step03" >> $file
 
 echo -en '\n' >> $file
-echo "#step 4: OMERO.server install as the omero system user" >> $file
+echo "#start-step04: OMERO.server install as the omero system user" >> $file
 if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
 	var="${OS//_/}"
 	echo "cp settings.env omero-$var.env step04_$OS_omero.sh ~omero " >> $file
@@ -81,7 +81,7 @@ else
 	line=$(sed -n ''$start',$p' step04_all_omero.sh)
 fi
 echo "$line" >> $file
-echo "#end step 4" >> $file
+echo "#end-step04" >> $file
 
 v=$OS
 if [ $OS = "debian8" ] ; then
@@ -89,34 +89,34 @@ if [ $OS = "debian8" ] ; then
 fi
 
 echo -en '\n' >> $file
-echo "#step 5: Install Web server, Nginx, as root" >> $file
+echo "#start-step05: Install Web server, Nginx, as root" >> $file
 start=$(sed -n '/#start-install/=' step05_"$v"_nginx.sh)
 start=$((start+1))
 line=$(sed -n ''$start',$p' step05_"$v"_nginx.sh)
 
 echo "$line" >> $file
-echo "#end step 5" >> $file
+echo "#end-step05" >> $file
 
 if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
 	v="centos6"
 fi
 
 echo -en '\n' >> $file
-echo "#step 6: Scripts to start OMERO and OMERO.web automatically as root" >> $file
+echo "#start-step06: Scripts to start OMERO and OMERO.web automatically as root" >> $file
 line=$(sed -n '2,$p' step06_"$v"_daemon.sh)
 echo "$line" >> $file
-echo "#end step 6" >> $file
+echo "#end-step06" >> $file
 
 echo -en '\n' >> $file
-echo "#step 7: Securing OMERO as root" >> $file
+echo "#start-step07: Securing OMERO as root" >> $file
 start=$(sed -n '/#start/=' step07_all_perms.sh)
 start=$((start+1))
 line=$(sed -n ''$start',$p' step07_all_perms.sh)
 echo "$line" >> $file
-echo "#end step 7" >> $file
+echo "#end-step07" >> $file
 
 echo -en '\n' >> $file
-echo "#step 8: Regular tasks" >> $file
+echo "#start-step08: Regular tasks" >> $file
 line=$(sed -n '2,$p' step08_all_cron.sh)
 echo "$line" >> $file
-echo "#end step 8" >> $file
+echo "#end-step08" >> $file

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# installation of the recommended dependencies
+# i.e. Java 1.8, nginx
+OS=${OS:-centos6}
+file=walkthrough_$OS.sh
+if [ -e $file ]; then
+	rm $file
+fi
+cat <<EOF > $file
+#!/bin/bash
+set -e -u -x
+source settings.env
+EOF
+
+echo -en '\n' >> $file
+echo "#step 1: Dependencies" >> $file
+if [ $OS = "centos7" ] ; then
+	line=$(sed -n '2,39p' step01_"$OS"_deps.sh)
+	echo "$line" >> $file
+	line=$(sed -n '46,$p' step01_"$OS"_deps.sh)
+else
+	line=$(sed -n '2,$p' step01_"$OS"_deps.sh)
+fi
+echo "$line" >> $file
+echo "#end step 1" >> $file
+
+# review the name of the original file.
+if [ $OS = "centos6_py27_ius" ] ; then
+	echo -en '\n' >> $file
+	echo "#step 1.1: virtual env" >> $file
+	line=$(sed -n '4,23p' step03_"$OS"_virtualenv_deps.sh)
+	echo "$line" >> $file
+	line=$(sed -n '28p' step03_"$OS"_virtualenv_deps.sh)
+	echo "$line" >> $file
+	echo "#end step 1.1:" >> $file
+fi
+
+echo -en '\n' >> $file
+echo "#step 2: Set-up" >> $file
+if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
+	line=$(sed -n '2,$p' step02_"$OS"_setup.sh)
+else 
+	line=$(sed -n '2,$p' step02_all_setup.sh)
+fi
+echo "$line" >> $file
+echo "#end step 2:" >> $file
+
+# postgres remove section
+echo -en '\n' >> $file
+echo "#step 3: Database user and database creation" >> $file
+line=$(sed -n '4,$p' step03_all_postgres.sh)
+echo "$line" >> $file
+echo "#end step 3" >> $file
+
+echo -en '\n' >> $file
+echo "#step 4: OMERO.server install" >> $file
+if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
+	var="${OS//_/}"
+	echo "cp settings.env omero-$var.env step04_$OS_omero.sh ~omero " >> $file
+	line=$(sed -n '6,$p' step04_"$OS"_omero.sh)
+else 
+	echo "cp settings.env step04_all_omero.sh ~omero " >> $file
+	line=$(sed -n '6,$p' step04_all_omero.sh)
+fi
+echo "$line" >> $file
+echo "#end step 4" >> $file
+
+v=$OS
+if [ $OS = "debian8" ] ; then
+	v="ubuntu1404"
+fi
+
+echo -en '\n' >> $file
+echo "#step 5: Web server nginx" >> $file
+if [ $OS = "centos6_py27_ius" ] ; then
+	line=$(sed -n '4,$p' step05_"$v"_nginx.sh)
+else
+	line=$(sed -n '2,$p' step05_"$v"_nginx.sh)
+fi 
+
+echo "$line" >> $file
+echo "#end step 5" >> $file
+
+if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
+	v="centos6"
+fi
+
+echo -en '\n' >> $file
+echo "#step 6: scripts to start OMERO and OMERO.web automatically" >> $file
+line=$(sed -n '2,$p' step06_"$v"_daemon.sh)
+echo "$line" >> $file
+echo "#end step 6" >> $file
+
+echo -en '\n' >> $file
+echo "#step 7: Securing OMERO" >> $file
+line=$(sed -n '6,$p' step07_all_perms.sh)
+echo "$line" >> $file
+echo "#end step 7" >> $file
+
+echo -en '\n' >> $file
+echo "#step 8: Regular tasks" >> $file
+line=$(sed -n '2,$p' step08_all_cron.sh)
+echo "$line" >> $file
+echo "#end step 8" >> $file

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -13,11 +13,15 @@ source settings.env
 EOF
 
 echo -en '\n' >> $file
-echo "#step 1: Dependencies" >> $file
+echo "#step 1: Install dependencies as root" >> $file
 if [ $OS = "centos7" ] ; then
-	line=$(sed -n '2,39p' step01_"$OS"_deps.sh)
+	number=$(sed -n '/#start-workaround/=' step01_"$OS"_deps.sh)
+	number=$((number-1))
+	line=$(sed -n '2,'$number'p' step01_"$OS"_deps.sh)
 	echo "$line" >> $file
-	line=$(sed -n '46,$p' step01_"$OS"_deps.sh)
+	number=$(sed -n '/#end-workaround/=' step01_"$OS"_deps.sh)
+	number=$((number+1))
+	line=$(sed -n ''$number',$p' step01_"$OS"_deps.sh)
 else
 	line=$(sed -n '2,$p' step01_"$OS"_deps.sh)
 fi
@@ -28,15 +32,22 @@ echo "#end step 1" >> $file
 if [ $OS = "centos6_py27_ius" ] ; then
 	echo -en '\n' >> $file
 	echo "#step 1.1: virtual env" >> $file
-	line=$(sed -n '4,23p' step03_"$OS"_virtualenv_deps.sh)
+	#find from where to start copying
+	start=$(sed -n '/#start-install/=' step03_"$OS"_virtualenv_deps.sh)
+	start=$((start+1))
+	number=$(sed -n '/#start-dev/=' step03_"$OS"_virtualenv_deps.sh)
+	number=$((number-1))
+	line=$(sed -n ''$start','$number'p' step03_"$OS"_virtualenv_deps.sh)
 	echo "$line" >> $file
-	line=$(sed -n '28p' step03_"$OS"_virtualenv_deps.sh)
+	number=$(sed -n '/#end-dev/=' step03_"$OS"_virtualenv_deps.sh)
+	number=$((number+1))
+	line=$(sed -n ''$number',$p' step03_"$OS"_virtualenv_deps.sh)
 	echo "$line" >> $file
 	echo "#end step 1.1:" >> $file
 fi
 
 echo -en '\n' >> $file
-echo "#step 2: Set-up" >> $file
+echo "#step 2: Set-up as root" >> $file
 if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
 	line=$(sed -n '2,$p' step02_"$OS"_setup.sh)
 else 
@@ -47,20 +58,27 @@ echo "#end step 2:" >> $file
 
 # postgres remove section
 echo -en '\n' >> $file
-echo "#step 3: Database user and database creation" >> $file
-line=$(sed -n '4,$p' step03_all_postgres.sh)
+echo "#step 3: Database user and database creation as root" >> $file
+#find from where to start copying
+start=$(sed -n '/#start-setup/=' step03_all_postgres.sh)
+start=$((start+1))
+line=$(sed -n ''$start',$p' step03_all_postgres.sh)
 echo "$line" >> $file
 echo "#end step 3" >> $file
 
 echo -en '\n' >> $file
-echo "#step 4: OMERO.server install" >> $file
+echo "#step 4: OMERO.server install as the omero system user" >> $file
 if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
 	var="${OS//_/}"
 	echo "cp settings.env omero-$var.env step04_$OS_omero.sh ~omero " >> $file
-	line=$(sed -n '6,$p' step04_"$OS"_omero.sh)
+	start=$(sed -n '/#start-install/=' step04_"$OS"_omero.sh)
+	start=$((start+1))
+	line=$(sed -n ''$start',$p' step04_"$OS"_omero.sh)
 else 
 	echo "cp settings.env step04_all_omero.sh ~omero " >> $file
-	line=$(sed -n '6,$p' step04_all_omero.sh)
+	start=$(sed -n '/#start-install/=' step04_all_omero.sh)
+	start=$((start+1))
+	line=$(sed -n ''$start',$p' step04_all_omero.sh)
 fi
 echo "$line" >> $file
 echo "#end step 4" >> $file
@@ -71,12 +89,10 @@ if [ $OS = "debian8" ] ; then
 fi
 
 echo -en '\n' >> $file
-echo "#step 5: Web server nginx" >> $file
-if [ $OS = "centos6_py27_ius" ] ; then
-	line=$(sed -n '4,$p' step05_"$v"_nginx.sh)
-else
-	line=$(sed -n '2,$p' step05_"$v"_nginx.sh)
-fi 
+echo "#step 5: Install Web server, Nginx, as root" >> $file
+start=$(sed -n '/#start-install/=' step05_"$v"_nginx.sh)
+start=$((start+1))
+line=$(sed -n ''$start',$p' step05_"$v"_nginx.sh)
 
 echo "$line" >> $file
 echo "#end step 5" >> $file
@@ -86,14 +102,16 @@ if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
 fi
 
 echo -en '\n' >> $file
-echo "#step 6: scripts to start OMERO and OMERO.web automatically" >> $file
+echo "#step 6: Scripts to start OMERO and OMERO.web automatically as root" >> $file
 line=$(sed -n '2,$p' step06_"$v"_daemon.sh)
 echo "$line" >> $file
 echo "#end step 6" >> $file
 
 echo -en '\n' >> $file
-echo "#step 7: Securing OMERO" >> $file
-line=$(sed -n '6,$p' step07_all_perms.sh)
+echo "#step 7: Securing OMERO as root" >> $file
+start=$(sed -n '/#start/=' step07_all_perms.sh)
+start=$((start+1))
+line=$(sed -n ''$start',$p' step07_all_perms.sh)
 echo "$line" >> $file
 echo "#end step 7" >> $file
 

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -155,3 +155,10 @@ line=$(sed -n '2,$p' step08_all_cron.sh)
 echo "$line" >> $file
 echo "#end-copy-omeroweb-cron" >> $file
 echo "#end-step08" >> $file
+
+if [[ $OS =~ "centos" ]]; then
+echo "#start-selinux" >> $file
+line=$(sed -n '2,$p' setup_centos_selinux.sh)
+echo "$line" >> $file
+echo "#end-selinux" >> $file
+fi

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -13,7 +13,7 @@ source settings.env
 EOF
 
 echo -en '\n' >> $file
-echo "#start-step01: Install dependencies as root" >> $file
+echo "#start-step01: As root, install dependencies" >> $file
 if [ $OS = "centos7" ] ; then
 	number=$(sed -n '/#start-workaround/=' step01_"$OS"_deps.sh)
 	number=$((number-1))
@@ -47,7 +47,7 @@ if [ $OS = "centos6_py27_ius" ] ; then
 fi
 
 echo -en '\n' >> $file
-echo "#start-step02: Set-up as root" >> $file
+echo "#start-step02: As root, create an omero system user and directory for the OMERO repository" >> $file
 if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
 	line=$(sed -n '2,$p' step02_"$OS"_setup.sh)
 else 
@@ -58,7 +58,7 @@ echo "#end-step02" >> $file
 
 # postgres remove section
 echo -en '\n' >> $file
-echo "#start-step03: Database user and database creation as root" >> $file
+echo "#start-step03: As root, create a database user and a database" >> $file
 #find from where to start copying
 start=$(sed -n '/#start-setup/=' step03_all_postgres.sh)
 start=$((start+1))
@@ -67,7 +67,7 @@ echo "$line" >> $file
 echo "#end-step03" >> $file
 
 echo -en '\n' >> $file
-echo "#start-step04: OMERO.server install as the omero system user" >> $file
+echo "#start-step04: As the omero system user, install the OMERO.server" >> $file
 if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
 	var="${OS//_/}"
 	echo "#start-copy-omeroscript" >> $file
@@ -93,7 +93,7 @@ if [ $OS = "debian8" ] ; then
 fi
 
 echo -en '\n' >> $file
-echo "#start-step05: Install Web server as root" >> $file
+echo "#start-step05: As root, install a Web server: Nginx or Apache" >> $file
 echo "#start-nginx" >> $file
 start=$(sed -n '/#start-install/=' step05_"$v"_nginx.sh)
 start=$((start+1))
@@ -109,7 +109,7 @@ if [ $OS = "centos6" ] || [ $OS = "centos6_py27_ius" ] ; then
 fi
 line=$(sed -n ''/#start-copy/','/#end-copy/'p' step05_"$v"_"$apachever".sh)
 echo "$line" >> $file
-echo "#start-configure: Configure OMERO.web as the omero system user" >> $file
+echo "#start-configure: As the omero system user, configure OMERO.web" >> $file
 start=$(sed -n '/#start-config/=' setup_omero_"$apachever".sh)
 start=$((start+1))
 line=$(sed -n ''$start',$p' setup_omero_"$apachever".sh)
@@ -130,13 +130,13 @@ if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
 fi
 
 echo -en '\n' >> $file
-echo "#start-step06: Scripts to start OMERO and OMERO.web automatically as root" >> $file
+echo "#start-step06: As root, run the scripts to start OMERO and OMERO.web automatically" >> $file
 line=$(sed -n '2,$p' step06_"$v"_daemon.sh)
 echo "$line" >> $file
 echo "#end-step06" >> $file
 
 echo -en '\n' >> $file
-echo "#start-step07: Securing OMERO as root" >> $file
+echo "#start-step07: As root, secure OMERO" >> $file
 start=$(sed -n '/#start/=' step07_all_perms.sh)
 start=$((start+1))
 line=$(sed -n ''$start',$p' step07_all_perms.sh)
@@ -144,7 +144,7 @@ echo "$line" >> $file
 echo "#end-step07" >> $file
 
 echo -en '\n' >> $file
-echo "#start-step08: Regular tasks" >> $file
+echo "#start-step08: As root, perform regular tasks" >> $file
 line=$(sed -n '2,$p' step08_all_cron.sh)
 echo "$line" >> $file
 echo "#end-step08" >> $file

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -70,12 +70,16 @@ echo -en '\n' >> $file
 echo "#start-step04: OMERO.server install as the omero system user" >> $file
 if [ $OS = "centos6_py27" ] || [ $OS = "centos6_py27_ius" ] ; then
 	var="${OS//_/}"
+	echo "#start-copy-omeroscript" >> $file
 	echo "cp settings.env omero-$var.env step04_$OS_omero.sh ~omero " >> $file
+	echo "#end-copy-omeroscript" >> $file
 	start=$(sed -n '/#start-install/=' step04_"$OS"_omero.sh)
 	start=$((start+1))
 	line=$(sed -n ''$start',$p' step04_"$OS"_omero.sh)
 else 
+	echo "#start-copy-omeroscript" >> $file
 	echo "cp settings.env step04_all_omero.sh ~omero " >> $file
+	echo "#end-copy-omeroscript" >> $file
 	start=$(sed -n '/#start-install/=' step04_all_omero.sh)
 	start=$((start+1))
 	line=$(sed -n ''$start',$p' step04_all_omero.sh)

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # installation of the recommended dependencies
 # i.e. Java 1.8, nginx
-OS=${OS:-centos6}
+OS=${OS:-centos7}
 file=walkthrough_$OS.sh
 if [ -e $file ]; then
 	rm $file

--- a/linux/install_centos6_apache22.sh
+++ b/linux/install_centos6_apache22.sh
@@ -25,6 +25,8 @@ bash -eux step05_centos6_apache22.sh
 #su - omero -c "OMERO.server/bin/omero admin start"
 #su - omero -c "OMERO.server/bin/omero web start"
 
+bash -eux setup_centos_selinux.sh
+
 bash -eux step06_centos6_daemon_no_web.sh
 
 bash -eux step07_all_perms.sh

--- a/linux/install_centos6_nginx.sh
+++ b/linux/install_centos6_nginx.sh
@@ -26,6 +26,8 @@ fi
 #su - omero -c "OMERO.server/bin/omero admin start"
 #su - omero -c "OMERO.server/bin/omero web start"
 
+bash -eux setup_centos_selinux.sh
+
 bash -eux step06_centos6_daemon.sh
 
 bash -eux step07_all_perms.sh

--- a/linux/install_centos6_py27_apache24.sh
+++ b/linux/install_centos6_py27_apache24.sh
@@ -25,6 +25,8 @@ bash -eux step05_centos6_py27_apache24.sh
 #su - omero -c "OMERO.server/bin/omero admin start"
 #su - omero -c "OMERO.server/bin/omero web start"
 
+bash -eux setup_centos_selinux.sh
+
 bash -eux step06_centos6_daemon_no_web.sh
 
 bash -eux step07_all_perms.sh

--- a/linux/install_centos6_py27_ius_apache22.sh
+++ b/linux/install_centos6_py27_ius_apache22.sh
@@ -28,6 +28,8 @@ bash -eux step05_centos6_py27_ius_apache22.sh
 #su - omero -c "OMERO.server/bin/omero admin start"
 #su - omero -c "OMERO.server/bin/omero web start"
 
+bash -eux setup_centos_selinux.sh
+
 bash -eux step06_centos6_daemon.sh
 
 bash -eux step07_all_perms.sh

--- a/linux/install_centos6_py27_ius_apache24.sh
+++ b/linux/install_centos6_py27_ius_apache24.sh
@@ -28,6 +28,8 @@ bash -eux step05_centos6_py27_ius_apache24.sh
 #su - omero -c "OMERO.server/bin/omero admin start"
 #su - omero -c "OMERO.server/bin/omero web start"
 
+bash -eux setup_centos_selinux.sh
+
 bash -eux step06_centos6_daemon.sh
 
 bash -eux step07_all_perms.sh

--- a/linux/install_centos6_py27_ius_nginx.sh
+++ b/linux/install_centos6_py27_ius_nginx.sh
@@ -28,6 +28,8 @@ fi
 #su - omero -c "OMERO.server/bin/omero admin start"
 #su - omero -c "OMERO.server/bin/omero web start"
 
+bash -eux setup_centos_selinux.sh
+
 bash -eux step06_centos6_daemon.sh
 
 bash -eux step07_all_perms.sh

--- a/linux/install_centos6_py27_nginx.sh
+++ b/linux/install_centos6_py27_nginx.sh
@@ -26,6 +26,8 @@ fi
 #su - omero -c "OMERO.server/bin/omero admin start"
 #su - omero -c "OMERO.server/bin/omero web start"
 
+bash -eux setup_centos_selinux.sh
+
 bash -eux step06_centos6_daemon.sh
 
 bash -eux step07_all_perms.sh

--- a/linux/install_centos7_apache24.sh
+++ b/linux/install_centos7_apache24.sh
@@ -25,6 +25,8 @@ bash -eux step05_centos7_apache24.sh
 #su - omero -c "OMERO.server/bin/omero admin start"
 #su - omero -c "OMERO.server/bin/omero web start"
 
+bash -eux setup_centos_selinux.sh
+
 bash -eux step06_centos7_daemon.sh
 
 #systemctl start omero.service

--- a/linux/install_centos7_nginx.sh
+++ b/linux/install_centos7_nginx.sh
@@ -25,6 +25,8 @@ fi
 #su - omero -c "OMERO.server/bin/omero admin start"
 #su - omero -c "OMERO.server/bin/omero web start"
 
+bash -eux setup_centos_selinux.sh
+
 bash -eux step06_centos7_daemon.sh
 
 #systemctl start omero.service

--- a/linux/setup_omero_apache22.sh
+++ b/linux/setup_omero_apache22.sh
@@ -4,6 +4,7 @@ set -e -u -x
 
 source settings.env
 
+#start-config
 OMERO.server/bin/omero config set omero.web.application_server wsgi
 OMERO.server/bin/omero web config apache --http "$OMERO_WEB_PORT" > OMERO.server/apache.conf.tmp
 OMERO.server/bin/omero web syncmedia

--- a/linux/setup_omero_apache24.sh
+++ b/linux/setup_omero_apache24.sh
@@ -4,6 +4,7 @@ set -e -u -x
 
 source settings.env
 
+#start-config
 OMERO.server/bin/omero config set omero.web.application_server wsgi
 OMERO.server/bin/omero web config apache24 --http "$OMERO_WEB_PORT" > OMERO.server/apache.conf.tmp
 OMERO.server/bin/omero web syncmedia

--- a/linux/step01_centos7_deps.sh
+++ b/linux/step01_centos7_deps.sh
@@ -37,12 +37,13 @@ yum -y install postgresql94-server postgresql94
 PGSETUP_INITDB_OPTIONS=--encoding=UTF8 /usr/pgsql-9.4/bin/postgresql94-setup initdb
 sed -i.bak -re 's/^(host.*)ident/\1md5/' /var/lib/pgsql/9.4/data/pg_hba.conf
 
-# Workaround to get postgresql running inside Docker
+#start-workaround to get postgresql running inside Docker
 if [ "${container:-}" = docker ]; then
 	sed -i 's/OOMScoreAdjust/#OOMScoreAdjust/' \
         	/usr/lib/systemd/system/postgresql-9.4.service
 	systemctl daemon-reload
 fi
+#end-workaround
 
 systemctl start postgresql-9.4.service
 systemctl enable postgresql-9.4.service

--- a/linux/step03_all_postgres.sh
+++ b/linux/step03_all_postgres.sh
@@ -2,6 +2,8 @@
 
 source settings.env
 
+#start-setup
+
 echo "CREATE USER $OMERO_DB_USER PASSWORD '$OMERO_DB_PASS'" | \
     su - postgres -c psql
 su - postgres -c "createdb -E UTF8 -O '$OMERO_DB_USER' '$OMERO_DB_NAME'"

--- a/linux/step03_centos6_py27_ius_virtualenv_deps.sh
+++ b/linux/step03_centos6_py27_ius_virtualenv_deps.sh
@@ -2,6 +2,8 @@
 
 OMEROVER=${OMEROVER:-omero}
 
+#start-install
+
 # Install the OMERO dependencies in a virtual environment
 # Create virtual env.
 # -p only require if it has been installed with python 2.6

--- a/linux/step03_centos6_py27_ius_virtualenv_deps.sh
+++ b/linux/step03_centos6_py27_ius_virtualenv_deps.sh
@@ -21,8 +21,10 @@ set -u
 # Django
 /home/omero/omeroenv/bin/pip2.7 install "Django>=1.8,<1.9"
 
+#start-dev
 if [ $OMEROVER = omerodev ] || [ $OMEROVER = omeromerge ] ; then
 	/home/omero/omeroenv/bin/pip2.7 install omego
 fi
+#end-dev
 
 deactivate

--- a/linux/step04_all_omero.sh
+++ b/linux/step04_all_omero.sh
@@ -4,6 +4,8 @@ set -e -u -x
 
 source settings.env
 
+#start-install
+
 SERVER=http://downloads.openmicroscopy.org/latest/omero5/server-ice35.zip
 
 wget $SERVER

--- a/linux/step04_centos6_py27_ius_omero.sh
+++ b/linux/step04_centos6_py27_ius_omero.sh
@@ -4,6 +4,7 @@ set -e -u -x
 
 source settings.env
 
+#start-install
 cd ~omero
 SERVER=http://downloads.openmicroscopy.org/latest/omero5/server-ice35.zip
 

--- a/linux/step04_centos6_py27_omero.sh
+++ b/linux/step04_centos6_py27_omero.sh
@@ -4,6 +4,7 @@ set -e -u -x
 
 source settings.env
 
+#start-install
 set +u
 source /opt/rh/python27/enable
 set -u

--- a/linux/step05_centos6_apache22.sh
+++ b/linux/step05_centos6_apache22.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+#start-copy
 cp setup_omero_apache22.sh ~omero
+#end-copy
 su - omero -c "bash -eux setup_omero_apache22.sh"
 
+#start-install
 yum -y install httpd mod_wsgi
 
 # See setup_omero_apache.sh for the apache config file creation

--- a/linux/step05_centos6_apache22.sh
+++ b/linux/step05_centos6_apache22.sh
@@ -12,4 +12,3 @@ cp ~omero/OMERO.server/apache.conf.tmp /etc/httpd/conf.d/omero-web.conf
 chkconfig httpd on
 service httpd start
 
-bash -eux setup_centos_selinux.sh

--- a/linux/step05_centos6_nginx.sh
+++ b/linux/step05_centos6_nginx.sh
@@ -18,4 +18,3 @@ cp ~omero/OMERO.server/nginx.conf.tmp /etc/nginx/conf.d/omero-web.conf
 
 service nginx start
 
-bash -eux setup_centos_selinux.sh

--- a/linux/step05_centos6_nginx.sh
+++ b/linux/step05_centos6_nginx.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+#start-install
 cat << EOF > /etc/yum.repos.d/nginx.repo
 [nginx]
 name=nginx repo

--- a/linux/step05_centos6_py27_apache24.sh
+++ b/linux/step05_centos6_py27_apache24.sh
@@ -3,6 +3,7 @@
 cp setup_omero_apache24.sh ~omero
 su - omero -c "bash -eux setup_omero_apache24.sh"
 
+#start-install
 yum -y install httpd24-httpd python27-mod_wsgi
 
 # See setup_omero_apache.sh for the apache config file creation

--- a/linux/step05_centos6_py27_apache24.sh
+++ b/linux/step05_centos6_py27_apache24.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
+#start-copy
 cp setup_omero_apache24.sh ~omero
+#end-copy
 su - omero -c "bash -eux setup_omero_apache24.sh"
 
 #start-install

--- a/linux/step05_centos6_py27_apache24.sh
+++ b/linux/step05_centos6_py27_apache24.sh
@@ -11,5 +11,3 @@ cp ~omero/OMERO.server/apache.conf.tmp /opt/rh/httpd24/root/etc/httpd/conf.d/ome
 
 chkconfig httpd24-httpd on
 service httpd24-httpd start
-
-bash -eux setup_centos_selinux.sh

--- a/linux/step05_centos6_py27_ius_apache22.sh
+++ b/linux/step05_centos6_py27_ius_apache22.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+#start-copy
 cp setup_omero_apache22.sh ~omero
-
+#end-copy
 su - omero -c "bash -eux setup_omero_apache22.sh"
 
+#start-install
 #install Apache 2.2
 yum -y install httpd
 

--- a/linux/step05_centos6_py27_ius_apache22.sh
+++ b/linux/step05_centos6_py27_ius_apache22.sh
@@ -17,5 +17,3 @@ cp ~omero/OMERO.server/apache.conf.tmp /etc/httpd/conf.d/omero-web.conf
 
 chkconfig httpd on
 service httpd start
-
-bash -eux setup_centos_selinux.sh

--- a/linux/step05_centos6_py27_ius_apache24.sh
+++ b/linux/step05_centos6_py27_ius_apache24.sh
@@ -32,5 +32,3 @@ EOF
 
 chkconfig httpd on
 service httpd start
-
-bash -eux setup_centos_selinux.sh

--- a/linux/step05_centos6_py27_ius_apache24.sh
+++ b/linux/step05_centos6_py27_ius_apache24.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+#start-copy
 cp setup_omero_apache24.sh ~omero
-
+#end-copy
 su - omero -c "bash -eux setup_omero_apache24.sh"
 
+#start-install
 #install httpd 2.4
 yum -y install httpd24u
 

--- a/linux/step05_centos6_py27_ius_nginx.sh
+++ b/linux/step05_centos6_py27_ius_nginx.sh
@@ -28,5 +28,3 @@ mv /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.disabled
 cp ~omero/OMERO.server/nginx.conf.tmp /etc/nginx/conf.d/omero-web.conf
 
 service nginx start
-
-bash -eux setup_centos_selinux.sh

--- a/linux/step05_centos6_py27_ius_nginx.sh
+++ b/linux/step05_centos6_py27_ius_nginx.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e -u -x
+#start-install
 
 cat << EOF > /etc/yum.repos.d/nginx.repo
 [nginx]

--- a/linux/step05_centos6_py27_nginx.sh
+++ b/linux/step05_centos6_py27_nginx.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+#start-install
 set +u
 source /opt/rh/python27/enable
 set -u

--- a/linux/step05_centos6_py27_nginx.sh
+++ b/linux/step05_centos6_py27_nginx.sh
@@ -21,5 +21,3 @@ mv /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.disabled
 cp ~omero/OMERO.server/nginx.conf.tmp /etc/nginx/conf.d/omero-web.conf
 
 service nginx start
-
-bash -eux setup_centos_selinux.sh

--- a/linux/step05_centos7_apache24.sh
+++ b/linux/step05_centos7_apache24.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+#start-copy
 cp setup_omero_apache24.sh ~omero
+#end-copy
 su - omero -c "bash -eux setup_omero_apache24.sh"
 
+#start-install
 yum -y install httpd mod_wsgi
 yum clean all
 

--- a/linux/step05_centos7_nginx.sh
+++ b/linux/step05_centos7_nginx.sh
@@ -12,4 +12,3 @@ cp ~omero/OMERO.server/nginx.conf.tmp /etc/nginx/conf.d/omero-web.conf
 systemctl enable nginx
 systemctl start nginx
 
-bash -eux setup_centos_selinux.sh

--- a/linux/step05_centos7_nginx.sh
+++ b/linux/step05_centos7_nginx.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+#start-install
 yum -y --enablerepo=cr install nginx
 
 pip install "gunicorn>=19.3"

--- a/linux/step05_ubuntu1404_apache24.sh
+++ b/linux/step05_ubuntu1404_apache24.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+#start-copy
 cp setup_omero_apache24.sh ~omero
+#end-copy
 su - omero -c "bash -eux setup_omero_apache24.sh"
 
+#start-install
 apt-get -y install apache2 libapache2-mod-wsgi
 
 # See setup_omero*.sh for the apache config file creation

--- a/linux/step05_ubuntu1404_nginx.sh
+++ b/linux/step05_ubuntu1404_nginx.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+#start-install
 apt-get -y install nginx
 
 pip install "gunicorn>=19.3"

--- a/linux/step07_all_perms.sh
+++ b/linux/step07_all_perms.sh
@@ -4,8 +4,9 @@ set -e -u -x
 
 source settings.env
 
+#start
 chmod go-rwx ~omero/OMERO.server/etc ~omero/OMERO.server/var
 
-# Optionally restrict accesss to the OMERO data directory
+#Optionally restrict accesss to the OMERO data directory
 #chmod go-rwx "$OMERO_DATA_DIR"
 


### PR DESCRIPTION
First step towards improvement of the doc installation
This "autogenerate" script will add the content of the various steps (some sections are excluded e.g. docker specific).
This will generate `walkthrough_OS.sh` files that we can then use in the omero-doc
The `walkthrough_OS.sh` files will have the `recommended` versions install e.g. java 1.8, etc. and should be used as detailed guideline (not as a runnable script!). The files should contain the markers so we can include the code snippets in the pages.
The `walkthrough_OS.sh` files will contain both Nginx and Apache installation steps.
This can easily be modified to use a `webserver` parameter

Markers have been added to the step files so we do not have hard-coded line number in the autogenerate (excluding 2 since all scripts will have `#!/bin/bash` on the first line)

usage: 
- Run  `OS=centos6 bash autogenerate.sh` to generate the `walkthrough_centos6.sh` file
- OS values should be one of the following: 
  - centos7 (default), centos6_py27, centos6_py27_ius, ubuntu1404, debian8, centos6

cc @hflynn @joshmoore @sbesson 
