### PR TITLE
debian 8 nginx

### DIFF
--- a/linux/step05_debian8_nginx.sh
+++ b/linux/step05_debian8_nginx.sh
@@ -5,6 +5,11 @@ cp setup_omero_nginx.sh ~omero
 #end-copy
 
 #start-install
+echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list
+wget http://nginx.org/keys/nginx_signing.key
+apt-key add nginx_signing.key
+rm nginx_signing.key
+apt-get update
 apt-get -y install nginx
 
 pip install -r ~omero/OMERO.server/share/web/requirements-py27-nginx.txt
@@ -12,8 +17,7 @@ pip install -r ~omero/OMERO.server/share/web/requirements-py27-nginx.txt
 # set up as the omero user.
 su - omero -c "bash -eux setup_omero_nginx.sh"
 
-cp ~omero/OMERO.server/nginx.conf.tmp /etc/nginx/sites-available/omero-web
-rm /etc/nginx/sites-enabled/default
-ln -s /etc/nginx/sites-available/omero-web /etc/nginx/sites-enabled/
+cp ~omero/OMERO.server/nginx.conf.tmp /etc/nginx/conf.d/omero-web.conf
+rm /etc/nginx/conf.d/default.conf
 
 service nginx start

--- a/linux/step05_debian8_nginx.sh
+++ b/linux/step05_debian8_nginx.sh
@@ -17,7 +17,7 @@ pip install -r ~omero/OMERO.server/share/web/requirements-py27-nginx.txt
 # set up as the omero user.
 su - omero -c "bash -eux setup_omero_nginx.sh"
 
+mv /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.disabled
 cp ~omero/OMERO.server/nginx.conf.tmp /etc/nginx/conf.d/omero-web.conf
-rm /etc/nginx/conf.d/default.conf
 
 service nginx start


### PR DESCRIPTION
Install nginx version 1.8 on debian 8
There is a change in the configuration between 1.6 (cf. ubuntu install) and 1.8

To test:
- Build the image i.e. `./docker-build.sh debian8_nginx/`
- Then run `docker run --rm -it -p 8080:80 -p 4063:4063 -p 4064:4064 omero_install_test_debian8_nginx`
- Check nginx version i.e. `nginx -v`
- Check that the login page of web is up.

cc @aleksandra-tarkowska 
