### PR TITLE
fix homebrew web login test

### DIFF
--- a/linux/test/test_login_to_web.sh
+++ b/linux/test/test_login_to_web.sh
@@ -10,7 +10,7 @@ COOKIES=cookies.txt
 LOGIN_URL=http://$WEB_HOST/webclient/login/
 LOGOUT_URL=http://$WEB_HOST/webclient/logout/
 
-source ../settings.env
+source `dirname $0`/../settings.env
 
 OMERO_ROOT='root'
 SERVER='1'

--- a/osx/step02_omero.sh
+++ b/osx/step02_omero.sh
@@ -8,7 +8,7 @@ set -x
 export PATH=/usr/local/bin:$PATH
 export OMERO_DATA_DIR=${OMERO_DATA_DIR:-~/OMERO.data}
 export PSQL_SCRIPT_NAME=${PSQL_SCRIPT_NAME:-OMERO.sql}
-export ROOT_PASSWORD=${ROOT_PASSWORD:-omero}
+export ROOT_PASSWORD=${ROOT_PASSWORD:-omero_root_password}
 export ICE=${ICE:-3.5}
 export HTTPPORT=${HTTPPORT:-8080}
 export LANG=${LANG:-en_US.UTF-8}

--- a/osx/step04_test.sh
+++ b/osx/step04_test.sh
@@ -8,7 +8,7 @@ set -x
 
 export PATH=/usr/local/bin:$PATH
 export HTTPPORT=${HTTPPORT:-8080}
-export ROOT_PASSWORD=${ROOT_PASSWORD:-omero}
+export ROOT_PASSWORD=${ROOT_PASSWORD:-omero_root_password}
 
 # Start PostgreSQL
 pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start

--- a/osx/step04_test.sh
+++ b/osx/step04_test.sh
@@ -30,34 +30,7 @@ omero import test.fake
 omero logout
 
 # Test simple Web connection
-COOKIES=cookies.txt
-LOGIN_URL=http://localhost:$HTTPPORT/webclient/login/
-LOGOUT_URL=http://localhost:$HTTPPORT/webclient/logout/
-SERVER='1'
-CURL_CMD="curl -i -k -s -c $COOKIES -b $COOKIES "
-$CURL_CMD $LOGIN_URL > /dev/null
-csrf_token=$(grep csrftoken $COOKIES | sed 's/^.*csrftoken\s*//' |  sed -e 's/^[[:space:]]*//' )
-DJANGO_TOKEN="csrfmiddlewaretoken=$csrf_token"
-
-echo "Perform login ..."
-RSP=$($CURL_CMD \
-        -e $LOGIN_URL \
-        -d "$DJANGO_TOKEN&username=root&password=$ROOT_PASSWORD&server=$SERVER" \
-        -X POST $LOGIN_URL)
-if grep -q id_server <<<$RSP; then
-  exit 1
-else
-  echo "You are logged in!"
-fi
-
-echo "Perform logout ..."
-$CURL_CMD \
-    -e $LOGIN_URL \
-    -d "$DJANGO_TOKEN" \
-    -X POST $LOGOUT_URL
-
-echo "You are logged out!"
-
+bash WEB_HOST="locahost:${HTTPPORT}" OMERO_ROOT_PASS=$ROOT_PASSWORD ../linux/test/test_login_to_web.sh
 
 # Stop OMERO.web
 nginx -c $(brew --prefix omero52)/etc/nginx.conf -s stop

--- a/osx/step04_test.sh
+++ b/osx/step04_test.sh
@@ -30,7 +30,7 @@ omero import test.fake
 omero logout
 
 # Test simple Web connection
-WEB_HOST="locahost:${HTTPPORT}" OMERO_ROOT_PASS=$ROOT_PASSWORD bash ../linux/test/test_login_to_web.sh
+WEB_HOST="localhost:${HTTPPORT}" OMERO_ROOT_PASS=$ROOT_PASSWORD bash ../linux/test/test_login_to_web.sh
 
 # Stop OMERO.web
 nginx -c $(brew --prefix omero52)/etc/nginx.conf -s stop

--- a/osx/step04_test.sh
+++ b/osx/step04_test.sh
@@ -30,7 +30,7 @@ omero import test.fake
 omero logout
 
 # Test simple Web connection
-bash WEB_HOST="locahost:${HTTPPORT}" OMERO_ROOT_PASS=$ROOT_PASSWORD ../linux/test/test_login_to_web.sh
+WEB_HOST="locahost:${HTTPPORT}" OMERO_ROOT_PASS=$ROOT_PASSWORD bash ../linux/test/test_login_to_web.sh
 
 # Stop OMERO.web
 nginx -c $(brew --prefix omero52)/etc/nginx.conf -s stop


### PR DESCRIPTION
This PR is an attempt to fix Homebrew test job that may silently failing on logging in to webclient, see https://ci.openmicroscopy.org/job/OMERO-DEV-merge-homebrew/ICE=3.5,OSX=snapper/149/console

To test check console https://ci.openmicroscopy.org/job/OMERO-DEV-merge-homebrew/ICE=3.5,OSX=snapper
