### PR TITLE
specify which ice version should be installed

### DIFF
--- a/linux/step01_centos6_ice_deps.sh
+++ b/linux/step01_centos6_ice_deps.sh
@@ -25,6 +25,6 @@ elif [ "$ICEVER" = "ice36" ]; then
 	yum -y install ice-all-runtime ice-all-devel
 
 	yum -y install openssl-devel bzip2-devel expat-devel
-	pip install zeroc-ice
+	pip install "zeroc-ice>3.5,<3.7"
 	#end-supported
 fi

--- a/linux/step01_centos6_py27_ice_deps.sh
+++ b/linux/step01_centos6_py27_ice_deps.sh
@@ -39,6 +39,6 @@ elif [ "$ICEVER" = "ice36" ]; then
 	set +u
 	source /opt/rh/python27/enable
 	set -u
-	pip install zeroc-ice
+	pip install "zeroc-ice>3.5,<3.7"
 	#end-supported
 fi

--- a/linux/step01_centos6_py27_ius_ice_deps.sh
+++ b/linux/step01_centos6_py27_ius_ice_deps.sh
@@ -40,7 +40,7 @@ elif [ "$ICEVER" = "ice36" ]; then
 	source /home/omero/omeroenv/bin/activate
 	set -u
 
-	/home/omero/omeroenv/bin/pip2.7 install zeroc-ice
+	/home/omero/omeroenv/bin/pip2.7 install "zeroc-ice>3.5,<3.7"
 
 	deactivate
 	#end-supported

--- a/linux/step01_centos7_ice_deps.sh
+++ b/linux/step01_centos7_ice_deps.sh
@@ -26,6 +26,6 @@ elif [ "$ICEVER" = "ice36" ]; then
 
 	yum -y install ice-all-runtime ice-all-devel
 
-	pip install zeroc-ice
+	pip install "zeroc-ice>3.5,<3.7"
 	#end-supported
 fi

--- a/linux/step01_debian8_ice_deps.sh
+++ b/linux/step01_debian8_ice_deps.sh
@@ -24,7 +24,7 @@ elif [ "$ICEVER" = "ice36" ]; then
  	cd ice-3.6.2/cpp		
  	make && make install
 
-	pip install zeroc-ice
+	pip install "zeroc-ice>3.5,<3.7"
 
 	echo /opt/Ice-3.6.2/lib64 > /etc/ld.so.conf.d/ice-x86_64.conf		
  	ldconfig

--- a/linux/step01_ubuntu1404_ice_deps.sh
+++ b/linux/step01_ubuntu1404_ice_deps.sh
@@ -18,6 +18,6 @@ elif [ "$ICEVER" = "ice36" ]; then
 	apt-get update
 	apt-get -y install zeroc-ice-all-runtime zeroc-ice-all-dev
 
-	pip install zeroc-ice
+	pip install "zeroc-ice>3.5,<3.7"
 	#end-supported
 fi

--- a/linux/test/test_services.sh
+++ b/linux/test/test_services.sh
@@ -45,6 +45,9 @@ docker exec -it $CNAME /bin/bash -c 'd=10; \
 #check OMERO.server service status
 docker exec -it $CNAME /bin/bash -c "service omero status -l"
 
+docker exec -it $CNAME /bin/bash -c "su - omero -c \"/home/omero/OMERO.server/bin/omero admin diagnostics\""
+
+
 # check OMERO.web status
 if [[ $ENV =~ "nginx" ]]; then
     docker exec -it $CNAME /bin/bash -c "service omero-web status -l"


### PR DESCRIPTION
This PR explicitly say which zeroc-ice should be installed in case 3.7 will be released.

centos 7

```
+ pip install 'zeroc-ice>3.5,<3.7'
Collecting zeroc-ice<3.7,>3.5
  Downloading zeroc-ice-3.6.2.tar.gz (1.1MB)

```
