### PR TITLE
centos6 omero user

### DIFF
--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -167,7 +167,7 @@ if [[ $OS =~ "centos6_py27" ]] ; then
 	line=$(sed -n ''$ns','$ne'p' $dir/step02_"$OS"_setup.sh)
 	line="$(echo -e "${line}" | sed -e 's/^[[:space:]]*//')"
 	echo "$line" >> $file
-	ns=$((number+3))
+	ns=$((number+2))
 	number=$(sed -n '/#start-ice/=' $dir/step02_"$OS"_setup.sh)
 	ne=$((number-1))
 	line=$(sed -n ''$ns','$ne'p' $dir/step02_"$OS"_setup.sh)


### PR DESCRIPTION
Make sure all the lines to create the "omero" system users are copied to the walkthrough

to test
- Go to linux directory
- run `bash autogenerate.sh`
- Check that in the `walkthrough_centos6_py27.sh` file, the following line `chmod a+X ~omero` is present
