### PR TITLE
Homebrew uninstall

### DIFF
--- a/osx/cleanup_homebrew.sh
+++ b/osx/cleanup_homebrew.sh
@@ -12,7 +12,4 @@ pkill nginx || echo No nginx running
 pkill postgres || echo No PostgreSQL running
 
 # Clean existing Homebrew
-rm -rf /usr/local/* && rm -rf /usr/local/.git || echo No Homebrew found
-
-# Remove Homebre cache
-# rm -rf /Library/Caches/Homebrew/* || echo No Homebrew cache found
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"

--- a/osx/step02_omero.sh
+++ b/osx/step02_omero.sh
@@ -7,7 +7,7 @@ set -x
 
 export PATH=/usr/local/bin:$PATH
 export OMERO_DATA_DIR=${OMERO_DATA_DIR:-~/OMERO.data}
-export PSQL_SCRIPT_NAME=${PSQL_SCRIPT_NAME:-OMERO.sql}
+export PSQL_SCRIPT_NAME=${PSQL_SCRIPT_NAME:-~/OMERO.sql}
 export ROOT_PASSWORD=${ROOT_PASSWORD:-omero_root_password}
 export ICE=${ICE:-3.5}
 export HTTPPORT=${HTTPPORT:-8080}

--- a/osx/step02_omero.sh
+++ b/osx/step02_omero.sh
@@ -7,7 +7,6 @@ set -x
 
 export PATH=/usr/local/bin:$PATH
 export OMERO_DATA_DIR=${OMERO_DATA_DIR:-~/OMERO.data}
-export PSQL_SCRIPT_NAME=${PSQL_SCRIPT_NAME:-~/OMERO.sql}
 export ROOT_PASSWORD=${ROOT_PASSWORD:-omero_root_password}
 export ICE=${ICE:-3.5}
 export HTTPPORT=${HTTPPORT:-8080}
@@ -50,9 +49,7 @@ omero config set omero.db.user db_user
 omero config set omero.db.pass db_password
 
 # Run DB script
-omero db script --password $ROOT_PASSWORD -f $PSQL_SCRIPT_NAME
-psql -h localhost -U db_user omero_database < $PSQL_SCRIPT_NAME
-rm $PSQL_SCRIPT_NAME
+omero db script --password $ROOT_PASSWORD -f - | psql -h localhost -U db_user omero_database
 
 # Stop PostgreSQL
 pg_ctl -D /usr/local/var/postgres -m fast stop

--- a/osx/step02_omero.sh
+++ b/osx/step02_omero.sh
@@ -32,6 +32,10 @@ bash bin/omero_python_deps
 # Set additional environment variables
 export ICE_CONFIG=$(brew --prefix omero52)/etc/ice.config
 
+# Reinitialize PSQL cluster to fix missing directories on OSX 10.11
+rm -rf /usr/local/var/postgres
+initdb -E UTF8 /usr/local/var/postgres
+
 # Start PostgreSQL
 pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
 


### PR DESCRIPTION
Following some the upgrade of the brew node by @rleigh-codelibre, some assumptions of the scripts within the job environment do not hold anymore.

This PR:
- uses the official uninstall script instead of our hard-coded `rm -rf` - this should be subjected to the same permissions as the install script (meaning `hudson` need to sudo)
- stores the generated sql script under `~` to fix permission issues under `/usr/local`
- reinitializes the PSQL database cluster using `initdb` to fix missing directories (see [1](https://coderwall.com/p/rjioeg/fixing-postgres-homebrew-install-after-yosemite-upgrade), [2](https://foobartel.com/articles/yosemite-upgrade-postgresql/), [3](http://apple.stackexchange.com/questions/209654/os-x-seems-to-delete-empty-directories))
