### PR TITLE
upgrade django-redis

### DIFF
--- a/linux/step01_centos6_py27_deps_websession.sh
+++ b/linux/step01_centos6_py27_deps_websession.sh
@@ -10,4 +10,4 @@ set +u
 source /opt/rh/python27/enable
 set -u
 
-pip install django-redis-cache>=1.6.5
+pip install django-redis>=4.4

--- a/linux/step01_centos6_py27_ius_deps_websession.sh
+++ b/linux/step01_centos6_py27_ius_deps_websession.sh
@@ -10,6 +10,6 @@ set +u
 source /home/omero/omeroenv/bin/activate
 set -u
 
-pip install django-redis-cache>=1.6.5
+pip install django-redis>=4.4
 
 deactivate

--- a/linux/step01_centos7_deps_websession.sh
+++ b/linux/step01_centos7_deps_websession.sh
@@ -2,7 +2,7 @@
 
 yum -y install redis python-redis
 
-pip install django-redis-cache>=1.6.5
+pip install django-redis>=4.4
 
 systemctl enable redis.service
 if [ ! "${container:-}" = docker ]; then

--- a/linux/step05_2_websessionconfig.sh
+++ b/linux/step05_2_websessionconfig.sh
@@ -19,4 +19,4 @@ fi
 
 # Register the app
 su - omero -c "OMERO.server/bin/omero config set omero.web.session_engine 'django.contrib.sessions.backends.cache'"
-su - omero -c "OMERO.server/bin/omero config set omero.web.caches '{\"default\": {\"BACKEND\": \"redis_cache.RedisCache\",\"LOCATION\": \"127.0.0.1:6379\"}}'"
+su - omero -c "OMERO.server/bin/omero config set omero.web.caches '{\"default\": {\"BACKEND\": \"django_redis.cache.RedisCache\",\"LOCATION\": \"redis://127.0.0.1:6379/0\"}}'"

--- a/osx/step01_deps_websession.sh
+++ b/osx/step01_deps_websession.sh
@@ -27,8 +27,8 @@ brew install redis
 brew services start redis
 
 # Install django-cache-redis
-pip install django-redis-cache>=1.6.5
+pip install django-redis>=4.4
 
 # Set up redis session backend
 omero config set omero.web.session_engine 'django.contrib.sessions.backends.cache'
-omero config set omero.web.caches '{"default": {"BACKEND": "redis_cache.RedisCache","LOCATION": "127.0.0.1:6379"}}'
+omero config set omero.web.caches '{"default": {"BACKEND": "django_redis.cache.RedisCache","LOCATION": "redis://127.0.0.1:6379/0"}}'


### PR DESCRIPTION
When using redis we have to use newer supported package https://trello.com/c/GIJQA0kg/177-redis-out-of-experimental
