### PR TITLE
Bugs in doc

### DIFF
--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -74,9 +74,11 @@ if [ $OS = "centos7" ] ; then
 	line=$(sed -n ''$ns','$ne'p' $dir/step01_"$OS"_deps.sh)
 	line="$(echo -e "${line}" | sed -e 's/^[[:space:]]*//')"
 
-	echo "$line" >> $file
+	# do not upgrade pip. this is not required in the doc
+	# echo "$line" >> $file
 	ne=$(($ne+3))
 	line=$(sed -n ''$ne',$p' $dir/step01_"$OS"_deps.sh)
+	line="$(echo -e "${line}" | sed -e 's/`dirname \$0`\///')"
 else
 	line=$(sed -n '2,$p' $dir/step01_"$OS"_deps.sh)
 fi

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -74,8 +74,7 @@ if [ $OS = "centos7" ] ; then
 	line=$(sed -n ''$ns','$ne'p' $dir/step01_"$OS"_deps.sh)
 	line="$(echo -e "${line}" | sed -e 's/^[[:space:]]*//')"
 
-	# do not upgrade pip. this is not required in the doc
-	# echo "$line" >> $file
+	echo "$line" >> $file
 	ne=$(($ne+3))
 	line=$(sed -n ''$ne',$p' $dir/step01_"$OS"_deps.sh)
 	line="$(echo -e "${line}" | sed -e 's/`dirname \$0`\///')"

--- a/linux/step03_all_postgres.sh
+++ b/linux/step03_all_postgres.sh
@@ -4,8 +4,7 @@ source `dirname $0`/settings.env
 
 #start-setup
 
-echo "CREATE USER $OMERO_DB_USER PASSWORD '$OMERO_DB_PASS'" | \
-    su - postgres -c psql
+echo "CREATE USER $OMERO_DB_USER PASSWORD '$OMERO_DB_PASS'" | su - postgres -c psql
 su - postgres -c "createdb -E UTF8 -O '$OMERO_DB_USER' '$OMERO_DB_NAME'"
 
 psql -P pager=off -h localhost -U "$OMERO_DB_USER" -l

--- a/linux/step04_all_omero.sh
+++ b/linux/step04_all_omero.sh
@@ -69,7 +69,6 @@ OMERO.server/bin/omero config set omero.data.dir "$OMERO_DATA_DIR"
 OMERO.server/bin/omero config set omero.db.name "$OMERO_DB_NAME"
 OMERO.server/bin/omero config set omero.db.user "$OMERO_DB_USER"
 OMERO.server/bin/omero config set omero.db.pass "$OMERO_DB_PASS"
-OMERO.server/bin/omero db script -f OMERO.server/db.sql "" "" "$OMERO_ROOT_PASS"
 #start-db
 
 if $(is_less_than $OMEROVER 5.1); then

--- a/linux/step05_centos6_py27_ius_apache22.sh
+++ b/linux/step05_centos6_py27_ius_apache22.sh
@@ -18,7 +18,7 @@ set -u
 
 # Install OMERO.web requirements
 file=~omero/OMERO.server/share/web/requirements-py27-apache.txt
-# introduce in 5.2.0
+# introduced in 5.2.0
 if [ -f $file ]; then
 	/home/omero/omeroenv/bin/pip2.7 install -r $file
 fi

--- a/linux/step05_centos6_py27_ius_nginx.sh
+++ b/linux/step05_centos6_py27_ius_nginx.sh
@@ -30,7 +30,7 @@ set -u
 # Install OMERO.web requirements
 file=~omero/OMERO.server/share/web/requirements-py27-nginx.txt
 
-# introduce in 5.2.0
+# introduced in 5.2.0
 if [ -f $file ]; then
 	#start-latest
 	/home/omero/omeroenv/bin/pip2.7 install -r $file

--- a/linux/step05_centos6_py27_nginx.sh
+++ b/linux/step05_centos6_py27_nginx.sh
@@ -29,7 +29,7 @@ yum -y install nginx
 file=~omero/OMERO.server/share/web/requirements-py27-nginx.txt
 
 
-# introduce in 5.2.0
+# introduced in 5.2.0
 if [ -f $file ]; then
 	#start-latest
 	pip install -r $file

--- a/linux/step05_centos7_nginx.sh
+++ b/linux/step05_centos7_nginx.sh
@@ -27,7 +27,7 @@ yum -y install nginx
 
 file=~omero/OMERO.server/share/web/requirements-py27-nginx.txt
 
-#introduce in 5.2.0
+# introduced in 5.2.0
 if [ -f $file ]; then
 	#start-latest
 	pip install -r $file

--- a/linux/step05_debian8_nginx.sh
+++ b/linux/step05_debian8_nginx.sh
@@ -20,7 +20,7 @@ apt-get -y install nginx
 
 file=~omero/OMERO.server/share/web/requirements-py27-nginx.txt
 
-# introduce in 5.2.0
+# introduced in 5.2.0
 if [ -f $file ]; then
 	#start-latest
 	pip install -r $file

--- a/linux/step05_ubuntu1404_nginx.sh
+++ b/linux/step05_ubuntu1404_nginx.sh
@@ -20,7 +20,7 @@ apt-get -y install nginx
 
 file=~omero/OMERO.server/share/web/requirements-py27-nginx.txt
 
-# introduce in 5.2.0
+# introduced in 5.2.0
 if [ -f $file ]; then
 	#start-latest
 	pip install -r $file


### PR DESCRIPTION
In this PR:

Cherry-pick relevant commits from https://github.com/ome/omero-install/pull/126

 * centos7 Remove "dirname $0" from walkthrough installation. The command is not needed when we described the installation steps in ome-doc
 * installation of OMERO: ``OMERO.server/bin/omero db script ...`` command was run twice
and also appeared twice in the walkthrough


to test:

 * go to linux directory
 * run bash autogenerate.sh
 *  Check that the content of ``walkthrough_centos7``: 
   * Check that there is no "dirname $0"
   *  Check that the command ``OMERO.server/bin/omero db script ...`` appears once