### PR TITLE
Homebrew repo (rebased onto dev_5_2)

### DIFF
--- a/osx/step01_deps.sh
+++ b/osx/step01_deps.sh
@@ -54,7 +54,7 @@ if [ "$TESTING_MODE" = true ]; then
     pip install -U scc || echo "scc installed"
 
     # Merge homebrew-alt PRs
-    cd /usr/local/Homebrew/Library/Taps/ome/homebrew-alt
+    cd $(brew --repository)/Library/Taps/ome/homebrew-alt
     scc merge master
 
     # Repair formula symlinks after merge

--- a/osx/step01_deps.sh
+++ b/osx/step01_deps.sh
@@ -54,7 +54,7 @@ if [ "$TESTING_MODE" = true ]; then
     pip install -U scc || echo "scc installed"
 
     # Merge homebrew-alt PRs
-    cd /usr/local/Library/Taps/ome/homebrew-alt
+    cd /usr/local/Homebrew/Library/Taps/ome/homebrew-alt
     scc merge master
 
     # Repair formula symlinks after merge


### PR DESCRIPTION

This is the same as gh-119 but rebased onto dev_5_2.

----

Following https://github.com/Homebrew/install/pull/60, some of the assumptions on the location of the Homebrew taps do not hold anymore. See https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-homebrew/27/ or https://ci.openmicroscopy.org/job/OMERO-DEV-merge-homebrew/270/ for failing builds.

This PR removes some of the fragility of our code by making use of `$(brew --repository)` to locate the root of the Homebrew directory. To test it, check the homebrew jobs become green again.


                