### PR TITLE
Homebrew

### DIFF
--- a/osx/cleanup_homebrew.sh
+++ b/osx/cleanup_homebrew.sh
@@ -12,7 +12,4 @@ pkill nginx || echo No nginx running
 pkill postgres || echo No PostgreSQL running
 
 # Clean existing Homebrew
-rm -rf /usr/local/* && rm -rf /usr/local/.git || echo No Homebrew found
-
-# Remove Homebre cache
-# rm -rf /Library/Caches/Homebrew/* || echo No Homebrew cache found
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"

--- a/osx/step01_deps.sh
+++ b/osx/step01_deps.sh
@@ -54,7 +54,7 @@ if [ "$TESTING_MODE" = true ]; then
     pip install -U scc || echo "scc installed"
 
     # Merge homebrew-alt PRs
-    cd /usr/local/Homebrew/Library/Taps/ome/homebrew-alt
+    cd $(brew --repository)/Library/Taps/ome/homebrew-alt
     scc merge master
 
     # Repair formula symlinks after merge

--- a/osx/step01_deps.sh
+++ b/osx/step01_deps.sh
@@ -54,7 +54,7 @@ if [ "$TESTING_MODE" = true ]; then
     pip install -U scc || echo "scc installed"
 
     # Merge homebrew-alt PRs
-    cd /usr/local/Library/Taps/ome/homebrew-alt
+    cd /usr/local/Homebrew/Library/Taps/ome/homebrew-alt
     scc merge master
 
     # Repair formula symlinks after merge

--- a/osx/step02_omero.sh
+++ b/osx/step02_omero.sh
@@ -7,7 +7,7 @@ set -x
 
 export PATH=/usr/local/bin:$PATH
 export OMERO_DATA_DIR=${OMERO_DATA_DIR:-~/OMERO.data}
-export PSQL_SCRIPT_NAME=${PSQL_SCRIPT_NAME:-OMERO.sql}
+export PSQL_SCRIPT_NAME=${PSQL_SCRIPT_NAME:-~/OMERO.sql}
 export ROOT_PASSWORD=${ROOT_PASSWORD:-omero_root_password}
 export ICE=${ICE:-3.5}
 export HTTPPORT=${HTTPPORT:-8080}

--- a/osx/step02_omero.sh
+++ b/osx/step02_omero.sh
@@ -7,7 +7,6 @@ set -x
 
 export PATH=/usr/local/bin:$PATH
 export OMERO_DATA_DIR=${OMERO_DATA_DIR:-~/OMERO.data}
-export PSQL_SCRIPT_NAME=${PSQL_SCRIPT_NAME:-~/OMERO.sql}
 export ROOT_PASSWORD=${ROOT_PASSWORD:-omero_root_password}
 export ICE=${ICE:-3.5}
 export HTTPPORT=${HTTPPORT:-8080}
@@ -50,9 +49,7 @@ omero config set omero.db.user db_user
 omero config set omero.db.pass db_password
 
 # Run DB script
-omero db script --password $ROOT_PASSWORD -f $PSQL_SCRIPT_NAME
-psql -h localhost -U db_user omero_database < $PSQL_SCRIPT_NAME
-rm $PSQL_SCRIPT_NAME
+omero db script --password $ROOT_PASSWORD -f - | psql -h localhost -U db_user omero_database
 
 # Stop PostgreSQL
 pg_ctl -D /usr/local/var/postgres -m fast stop

--- a/osx/step02_omero.sh
+++ b/osx/step02_omero.sh
@@ -32,6 +32,10 @@ bash bin/omero_python_deps
 # Set additional environment variables
 export ICE_CONFIG=$(brew --prefix omero52)/etc/ice.config
 
+# Reinitialize PSQL cluster to fix missing directories on OSX 10.11
+rm -rf /usr/local/var/postgres
+initdb -E UTF8 /usr/local/var/postgres
+
 # Start PostgreSQL
 pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
 


### PR DESCRIPTION
Combined commits from gh-119 and gh-120
----

Following https://github.com/Homebrew/install/pull/60, some of the assumptions on the location of the Homebrew taps do not hold anymore. See https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-homebrew/27/ or https://ci.openmicroscopy.org/job/OMERO-DEV-merge-homebrew/270/ for failing builds.

This PR removes some of the fragility of our code by making use of `$(brew --repository)` to locate the root of the Homebrew directory. To test it, check the homebrew jobs become green again.