### PR TITLE
Ubuntu 1604

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
   - ENV=centos6_py27_ius_apache22
   - ENV=centos6_py27_ius_apache24
   - ENV=centos6_py27_ius_nginx
+  - ENV=ubuntu1604_nginx
+  - ENV=ubuntu1604_apache24
 
 before_install:  
   - sudo apt-get update

--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -13,7 +13,7 @@ echo "${l}"
 
 #generate the walkthrough for all supported os
 function generate_all() {
-	values=(centos7 centos6_py27 centos6_py27_ius ubuntu1404 debian8)
+	values=(centos7 centos6_py27 centos6_py27_ius ubuntu1404 debian8 ubuntu1604)
 	for os in "${values[@]}"; do
   		echo "${os}"
   		 generate ${os}

--- a/linux/test/ubuntu1604_apache24/Dockerfile
+++ b/linux/test/ubuntu1604_apache24/Dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile for testing the OMERO Linux installation instructions
+# Not intended for production use
+FROM ubuntu:16.04
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+ARG WEBSESSION=false
+ARG WEBAPPS=false
+ARG OMEROVER=latest
+ARG JAVAVER=openjdk18
+ARG ICEVER=ice36
+ARG PGVER=pg94
+
+RUN update-locale LANG=C.UTF-8
+
+ADD omero-install-test.zip /
+RUN apt-get update && apt-get -y install unzip && unzip omero-install-test.zip
+
+RUN cd omero-install-test && \
+	bash install_ubuntu1404_apache24.sh && \
+	bash docker_shutdown_ubuntu1404.sh
+ADD run.sh /home/omero/run.sh
+
+EXPOSE 80 4063 4064
+CMD ["/bin/bash", "-e", "/home/omero/run.sh"]

--- a/linux/test/ubuntu1604_apache24/run.sh
+++ b/linux/test/ubuntu1604_apache24/run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+WEBSESSION=false
+
+while [[ $# > 1 ]]
+do
+key="$1"
+
+case $key in
+    -w|--websession)
+    WEBSESSION="$2"
+    shift # past argument
+    ;;
+    *)
+            # unknown option
+    ;;
+esac
+shift # past argument or value
+done
+
+service postgresql start
+if [ "$WEBSESSION" = "true" ]; then
+	service redis start
+fi
+#service crond start # Doesn't work in Docker
+cron
+service omero start
+service apache2 start
+exec bash

--- a/linux/test/ubuntu1604_nginx/Dockerfile
+++ b/linux/test/ubuntu1604_nginx/Dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile for testing the OMERO Linux installation instructions
+# Not intended for production use
+FROM ubuntu:16.04
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+ARG WEBSESSION=false
+ARG WEBAPPS=false
+ARG OMEROVER=latest
+ARG JAVAVER=openjdk18
+ARG ICEVER=ice36
+ARG PGVER=pg94
+
+RUN update-locale LANG=C.UTF-8
+
+ADD omero-install-test.zip /
+RUN apt-get update && apt-get -y install unzip && unzip omero-install-test.zip
+
+RUN cd omero-install-test && \
+	bash install_ubuntu1404_nginx.sh && \
+	bash docker_shutdown_ubuntu1404.sh
+ADD run.sh /home/omero/run.sh
+
+EXPOSE 80 4063 4064
+CMD ["/bin/bash", "-e", "/home/omero/run.sh"]

--- a/linux/test/ubuntu1604_nginx/run.sh
+++ b/linux/test/ubuntu1604_nginx/run.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+WEBSESSION=false
+
+while [[ $# > 1 ]]
+do
+key="$1"
+
+case $key in
+    -w|--websession)
+    WEBSESSION="$2"
+    shift # past argument
+    ;;
+    *)
+            # unknown option
+    ;;
+esac
+shift # past argument or value
+done
+
+service postgresql start
+if [ "$WEBSESSION" = "true" ]; then
+	service redis start
+fi
+#service crond start # Doesn't work in Docker
+cron
+service omero start
+service nginx start
+service omero-web start
+exec bash


### PR DESCRIPTION
This adds support for Ubuntu 16.04
it was mentioned few times on the list/forum
The various step scripts do not need to be modified (need to check pg one). Ideally they could be renamed but us moving to ansible and don't think that is needed

This also sets the default for ice to 3.6