### PR TITLE
centos7 fix

### DIFF
--- a/linux/test/centos7_apache24/Dockerfile
+++ b/linux/test/centos7_apache24/Dockerfile
@@ -2,7 +2,7 @@
 # Not intended for production use
 # Note to enable systemd this must be run with on a host with systemd
 # and additional flaks, see the omero-ssh-c7 README
-FROM openmicroscopy/omero-ssh-c7:0.1.0
+FROM openmicroscopy/omero-ssh-c7:0.1.0-1
 
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 

--- a/linux/test/centos7_nginx/Dockerfile
+++ b/linux/test/centos7_nginx/Dockerfile
@@ -2,7 +2,7 @@
 # Not intended for production use
 # Note to enable systemd this must be run with on a host with systemd
 # and additional flaks, see the omero-ssh-c7 README
-FROM openmicroscopy/omero-ssh-c7:0.1.0
+FROM openmicroscopy/omero-ssh-c7:0.1.0-1
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 # Remove the existing omero user


### PR DESCRIPTION
Use the new upstream image
This should fix the failure due to "locale" issues

See also https://github.com/openmicroscopy/omero-ssh-c7-docker/releases/tag/0.1.0-1

Travis should hopefully be green for centos7