### PR TITLE
Install using ice 3.6

### DIFF
--- a/osx/step02_omero.sh
+++ b/osx/step02_omero.sh
@@ -19,7 +19,7 @@ export LANGUAGE=${LANGUAGE:-en_US:en}
 
 # Install OMERO
 OMERO_PYTHONPATH=$(brew --prefix omero52)/lib/python
-brew install omero52 --with-nginx --with-cpp
+brew install omero52 --with-nginx --with-cpp --with-ice36
 export PYTHONPATH=$OMERO_PYTHONPATH
 VERBOSE=1 brew test omero52
 


### PR DESCRIPTION
Allow to run the formula with ice 36 instead of 3.5
Due to an error with zeroc-ice35 formula
