### PR TITLE
Omero version

### DIFF
--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -260,6 +260,7 @@ ne=$((number-1))
 line=$(sed -n ''$ns','$ne'p' $dir/step04_all_omero.sh)
 line="$(echo -e "${line}" | sed -e 's/^[[:space:]]*//')"
 line=$(echo -e "${line}" | sed -e "s/\$OMEROVER/5.2/g")
+line=$(echo -e "${line}" | sed -e "s/\$icevalue/3.5/g")
 echo "$line" >> $file
 echo "#end-release-ice35" >> $file
 
@@ -270,7 +271,6 @@ number=$(sed -n '/#end-release-ice36/=' $dir/step04_all_omero.sh)
 ne=$((number-1))
 line=$(sed -n ''$ns','$ne'p' $dir/step04_all_omero.sh)
 line="$(echo -e "${line}" | sed -e 's/^[[:space:]]*//')"
-line=$(echo -e "${line}" | sed -e "s/\$OMEROVER/5.2/g")
 echo "$line" >> $file
 echo "#end-release-ice36" >> $file
 

--- a/linux/step04_all_omero.sh
+++ b/linux/step04_all_omero.sh
@@ -19,7 +19,7 @@ fi
 if [[ ! $PY_ENV = "py27_ius" ]]; then
 	#start-venv
 	virtualenv /home/omero/omeroenv
-	/home/omero/omeroenv/bin/pip install omego==0.4.0
+	/home/omero/omeroenv/bin/pip install omego==0.6.0
 	#end-venv
 fi
 
@@ -36,23 +36,13 @@ if [ "$ICEVER" = "ice36" ]; then
 		unzip -q OMERO.server*
 		#end-release-ice36
 	fi
-else
-	# do not use omego for the release version
-	# Handle release version via download page.
-	if [ $OMEROVER == "latest" ]; then
-  		# one release version
-  		#start-release-ice35
-  		cd ~omero
-  		SERVER=http://downloads.openmicroscopy.org/latest/omero5.3/server-ice35.zip
-		wget $SERVER -O OMERO.server-ice35.zip
-		unzip -q OMERO.server*
-		#end-release-ice35
-	fi
 fi
 # no server downloaded
 if [ ! -d OMERO.server* ]; then
 	# dev branches installed via omego
+	#start-release-ice35
 	/home/omero/omeroenv/bin/omego download --ice $icevalue --branch $OMEROVER server
+	#end-release-ice35
 fi
 
 #start-link


### PR DESCRIPTION
#it is no longer possible to retrieve the version of omero server with ice 3.5 from the download page
The version will be installed using omego
This requires a bump of omego i.e.  version 0.6.0

To test run for example
``ICEVER=ice35 ./docker-build.sh ubuntu1604_nginx``