### PR TITLE
Expand PATH to find Python/Pip executables

### DIFF
--- a/osx/step01_deps.sh
+++ b/osx/step01_deps.sh
@@ -5,7 +5,7 @@ set -e
 set -u
 set -x
 
-export PATH=/usr/local/bin:$PATH
+export PATH=/usr/local/bin:/usr/local/opt/python/libexec/bin:$PATH
 export LANG=${LANG:-en_US.UTF-8}
 export LANGUAGE=${LANGUAGE:-en_US:en}
 

--- a/osx/step01_deps_websession.sh
+++ b/osx/step01_deps_websession.sh
@@ -5,7 +5,7 @@ set -e
 set -u
 set -x
 
-export PATH=/usr/local/bin:$PATH
+export PATH=/usr/local/bin:/usr/local/opt/python/libexec/bin:$PATH
 export LANG=${LANG:-en_US.UTF-8}
 export LANGUAGE=${LANGUAGE:-en_US:en}
 

--- a/osx/step02_omero.sh
+++ b/osx/step02_omero.sh
@@ -5,7 +5,7 @@ set -e
 set -u
 set -x
 
-export PATH=/usr/local/bin:$PATH
+export PATH=/usr/local/bin:/usr/local/opt/python/libexec/bin:$PATH
 export OMERO_DATA_DIR=${OMERO_DATA_DIR:-~/OMERO.data}
 export ROOT_PASSWORD=${ROOT_PASSWORD:-omero_root_password}
 export ICE=${ICE:-3.5}

--- a/osx/step03_nginx.sh
+++ b/osx/step03_nginx.sh
@@ -5,7 +5,7 @@ set -e
 set -u
 set -x
 
-export PATH=/usr/local/bin:$PATH
+export PATH=/usr/local/bin:/usr/local/opt/python/libexec/bin:$PATH
 export HTTPPORT=${HTTPPORT:-8080}
 export ICE_CONFIG=$(brew --prefix omero52)/etc/ice.config
 export PYTHONPATH=$(brew --prefix omero52)/lib/python

--- a/osx/step04_test.sh
+++ b/osx/step04_test.sh
@@ -6,7 +6,7 @@ set -e
 set -u
 set -x
 
-export PATH=/usr/local/bin:$PATH
+export PATH=/usr/local/bin:/usr/local/opt/python/libexec/bin:$PATH
 export HTTPPORT=${HTTPPORT:-8080}
 export ROOT_PASSWORD=${ROOT_PASSWORD:-omero_root_password}
 


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/pull/14408

Following a recent change in Homebrew core, the `python` executable is no longer available under the `PATH` by default. This PR implements the workaround used in https://github.com/Homebrew/brew/pull/2897 to minimize the number of changes in the code.

An alternative might be to use a virtual environment using the system Python i.e.

```
sudo easy_install pip
sudo pip install virtualenv
virtualenv /tmp/omero_venv
source /tmp/omero_venv
```

To be reviewed with @jburel in the context of OMERO 5.4.0