### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-group: deprecated-2017Q2
 services:
   - docker
 env:
@@ -14,7 +13,6 @@ env:
 
 before_install:  
   - sudo apt-get update
-  - sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" docker-engine
   - sudo apt-get -y install shunit2
 script:
     - cd linux/test
@@ -22,4 +20,3 @@ script:
     - if [[ "$ENV" =~ "centos7" ]]; then ./test_services.sh; fi
     - cd ..
     - ./autogenerate.sh
-    # Sadly, no test for OS X here.


### PR DESCRIPTION
Remove
 
* group: deprecated-2017Q2
* use services docker i.e. do not install docker engine

To test:
  * open a travis build and check that 14.04 (trusty) has been used
  * check that travis is green