### PR TITLE
Set omero systemd UMask=0002

### DIFF
--- a/linux/omero-systemd.service
+++ b/linux/omero-systemd.service
@@ -9,6 +9,7 @@ After=network.service
 
 [Service]
 User=omero
+UMask=0002
 Type=forking
 PIDFile=/home/omero/OMERO.server/var/master/master.pid
 Restart=no

--- a/linux/omero-systemd.service
+++ b/linux/omero-systemd.service
@@ -9,7 +9,6 @@ After=network.service
 
 [Service]
 User=omero
-UMask=0002
 Type=forking
 PIDFile=/home/omero/OMERO.server/var/master/master.pid
 Restart=no
@@ -18,6 +17,8 @@ RestartSec=10
 TimeoutSec=300
 ExecStart=/home/omero/OMERO.server/bin/omero admin start
 ExecStop=/home/omero/OMERO.server/bin/omero admin stop
+# If you want to enable in-place imports uncomment this:
+#UMask=0002
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Set the default OMERO systemd umask to 0022 to enable in-place imports to work by enabling group-write. PR review should include a consideration of whether this relaxation of permissions is justified. If it's not we should update https://github.com/openmicroscopy/ansible-role-omero-server/blob/2.0.2/defaults/main.yml#L28 instead

See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2018-January/006865.html