### PR TITLE
Check version

### DIFF
--- a/linux/step01_debian9_pg_deps.sh
+++ b/linux/step01_debian9_pg_deps.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 PGVER=${PGVER:-pg96}
+if [[ "$PGVER" =~ ^(pg94|pg95)$ ]]; then
+    PGVER="pg96"
+fi
 
 if [ "$PGVER" = "pg96" ]; then
     # Postgres installation: version installed will be 9.6


### PR DESCRIPTION
This is a side effect of adding support of a new postgresql version
See https://github.com/ome/omero-install/pull/188

to test run:
 * ``./docker-build.sh debian9_nginx``
 * `` PGVER=pg95 ./docker-build.sh debian9_nginx``

cc @dominikl 