### PR TITLE
Debian9: Use omero.glacier2.IceSSL.Ciphers to set @SECLEVEL=0

### DIFF
--- a/linux/step04_omero_patch_openssl.sh
+++ b/linux/step04_omero_patch_openssl.sh
@@ -2,6 +2,5 @@
 
 #start-seclevel
 OMERO.server/bin/omero config set omero.glacier2.IceSSL.Ciphers HIGH:ADH:@SECLEVEL=0
-sed -i 's/\("IceSSL.Ciphers".*ADH\)/\1:@SECLEVEL=0/' OMERO.server/lib/python/omero/clients.py
 #end-seclevel
 #clean files

--- a/linux/step04_omero_patch_openssl.sh
+++ b/linux/step04_omero_patch_openssl.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 #start-seclevel
-sed -i.bak 's/\("IceSSL.Ciphers".*ADH\)/\1:@SECLEVEL=0/' OMERO.server/lib/python/omero/clients.py OMERO.server/etc/templates/grid/templates.xml
+OMERO.server/bin/omero config set omero.glacier2.IceSSL.Ciphers HIGH:ADH:@SECLEVEL=0
+sed -i 's/\("IceSSL.Ciphers".*ADH\)/\1:@SECLEVEL=0/' OMERO.server/lib/python/omero/clients.py
 #end-seclevel
 #clean files
-rm OMERO.server/lib/python/omero/clients.py.bak
-rm OMERO.server/etc/templates/grid/templates.xml.bak


### PR DESCRIPTION
Use the [new `omero.glacier2.IceSSL.Ciphers` property](https://github.com/openmicroscopy/openmicroscopy/pull/5998) on https://docs.openmicroscopy.org/omero/5.4.10/sysadmins/troubleshooting.html#openssl-version

~Also use `sed -i` for the remaining file to prevent the `.bak` file being created.~

~If https://github.com/openmicroscopy/openmicroscopy/pull/6007 is judged safe then the `sed ... clients.py` command could be removed completely.~ This was merged