### PR TITLE
latest 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ env:
   - ENV=centos7_nginx PGVER=pg96
   - ENV=ubuntu1604_nginx PGVER=pg96
   - ENV=debian9_nginx PGVER=pg96
-  - ENV=ubuntu1604_nginx JAVAVER=openjdk11
-  - ENV=debian9_nginx JAVAVER=openjdk11
-  - ENV=debian9_nginx JAVAVER=oracle11
-  - ENV=ubuntu1604_nginx JAVAVER=oracle11
+  #- ENV=ubuntu1604_nginx JAVAVER=openjdk11
+  #- ENV=debian9_nginx JAVAVER=openjdk11
+  #- ENV=debian9_nginx JAVAVER=oracle11
+  #- ENV=ubuntu1604_nginx JAVAVER=oracle11
 
 before_install:  
   - sudo apt-get update

--- a/linux/step04_all_omero.sh
+++ b/linux/step04_all_omero.sh
@@ -23,7 +23,7 @@ if [ "$ICEVER" = "ice36" ]; then
 	if [ $OMEROVER == "latest" ]; then
 		#start-release-ice36
 		cd ~omero
-		SERVER=https://downloads.openmicroscopy.org/latest/omero5/server-ice36.zip
+		SERVER=https://downloads.openmicroscopy.org/latest/omero5.5/server-ice36.zip
 		wget -q $SERVER -O OMERO.server-ice36.zip
 		unzip -q OMERO.server*
 		#end-release-ice36


### PR DESCRIPTION
point to omero5.5 (5.5.0-rc1)
This is required otherwise SECLEVEL change done https://github.com/ome/omero-install/pull/197
will imply that build will fail

The server currently does not start on Java 11. I discovered that last night. disabling for now the java 11 jobs
cc @mtbc 