### PR TITLE
CentOS 7 use wheel

### DIFF
--- a/linux/step01_centos7_ice_deps.sh
+++ b/linux/step01_centos7_ice_deps.sh
@@ -13,7 +13,7 @@ if [ "$ICEVER" = "ice36" ]; then
 
     yum -y install ice-all-runtime
 
-    pip install "zeroc-ice>3.5,<3.7"
+    pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
     #end-recommended
     # reset the locale
     localedef -i en_US -f UTF-8 en_US.UTF-8
@@ -26,6 +26,6 @@ elif [ "$ICEVER" = "ice36-devel" ]; then
 
     yum -y install ice-all-runtime ice-all-devel
 
-    pip install "zeroc-ice>3.5,<3.7"
+    pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
     localedef -i en_US -f UTF-8 en_US.UTF-8
 fi


### PR DESCRIPTION
Speed up the installation of ice py
This matches what is currently done for Ubuntu and Debian
