### PR TITLE
Wheel rollback

### DIFF
--- a/linux/step01_ubuntu1604_deps.sh
+++ b/linux/step01_ubuntu1604_deps.sh
@@ -4,5 +4,4 @@ apt-get -y install \
 	unzip \
 	wget \
 	python3 \
-	python3-venv \
-	python3-wheel
+	python3-venv

--- a/linux/step04_all_omero_install.sh
+++ b/linux/step04_all_omero_install.sh
@@ -8,6 +8,7 @@ set -eux
 
 #start-install-omero-py
 # Install omero-py
+$VENV_SERVER/bin/pip install wheel
 $VENV_SERVER/bin/pip install "omero-py>=5.6.dev4"
 #end-install-omero-py
 


### PR DESCRIPTION
Looking closely at the log, I could see ``invalid command 'bdist_wheel'``
I have installed ``wheel`` in the virtual env and the error is no longer there

* Check that travis is green
* Check that the error ``invalid command 'bdist_wheel'`` is not in the travis log

cc @dominikl 