### PR TITLE
install pytables

### DIFF
--- a/linux/step01_centos7_ice_venv.sh
+++ b/linux/step01_centos7_ice_venv.sh
@@ -9,4 +9,7 @@ python3 -mvenv $VENV_SERVER
 
 # Install the Ice Python binding
 $VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
+
+# Install pytables
+$VENV_SERVER/bin/pip install tables
 #end-ice-py

--- a/linux/step01_debian10_ice_venv.sh
+++ b/linux/step01_debian10_ice_venv.sh
@@ -9,4 +9,7 @@ python3 -mvenv $VENV_SERVER
 
 # Install the Ice Python binding
 $VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-debian10/releases/download/0.1.0/zeroc_ice-3.6.5-cp37-cp37m-linux_x86_64.whl
+
+# Install pytables
+$VENV_SERVER/bin/pip install tables
 #end-ice-py

--- a/linux/step01_debian9_ice_venv.sh
+++ b/linux/step01_debian9_ice_venv.sh
@@ -9,4 +9,7 @@ python3 -mvenv $VENV_SERVER
 
 # Install the Ice Python binding
 $VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-py-debian9/releases/download/0.2.0/zeroc_ice-3.6.5-cp35-cp35m-linux_x86_64.whl
+
+# Install pytables
+$VENV_SERVER/bin/pip install "tables==3.4.4"
 #end-ice-py

--- a/linux/step01_ubuntu1604_ice_venv.sh
+++ b/linux/step01_ubuntu1604_ice_venv.sh
@@ -9,4 +9,7 @@ python3 -mvenv $VENV_SERVER
 
 # Install the Ice Python binding
 $VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-py-ubuntu1604/releases/download/0.2.0/zeroc_ice-3.6.5-cp35-cp35m-linux_x86_64.whl
+
+# Install pytables
+$VENV_SERVER/bin/pip install "tables==3.4.4"
 #end-ice-py

--- a/linux/step01_ubuntu1804_ice_venv.sh
+++ b/linux/step01_ubuntu1804_ice_venv.sh
@@ -9,4 +9,7 @@ python3 -mvenv $VENV_SERVER
 
 # Install the Ice Python binding
 $VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-ubuntu1804/releases/download/0.3.0/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
+
+# Install pytables
+$VENV_SERVER/bin/pip install tables
 #end-ice-py


### PR DESCRIPTION
Pytables were previously installed using the package manager
This was removed in https://github.com/ome/omero-install/pull/216
under the assumption that this will be included in ``omero-py``
this is not the case.
This should fix the missing installation step in our guide
See https://github.com/ome/ome-documentation/pull/2097