### PR TITLE
Pg12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ services:
 env:
   - ENV=centos7 PGVER=pg10 JAVAVER=openjdk1.8
   - ENV=ubuntu1804 PGVER=pg10 JAVAVER=openjdk1.8
+  - ENV=ubuntu1804 PGVER=pg12
+  - ENV=debian9 PGVER=pg12
+  - ENV=debian10 PGVER=pg12
+  - ENV=centos7 PGVER=pg12
   - ENV=ubuntu1604
   - ENV=debian9
   - ENV=ubuntu1804

--- a/linux/install_centos7.sh
+++ b/linux/install_centos7.sh
@@ -23,7 +23,7 @@ bash -eux step01_centos7_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg94|pg95|pg96|pg10|pg11)$ ]]; then
+if [[ "$PGVER" =~ ^(pg94|pg95|pg96|pg10|pg11|pg12)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 

--- a/linux/install_debian10.sh
+++ b/linux/install_debian10.sh
@@ -27,7 +27,7 @@ bash -eux step01_debian10_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg94|pg95|pg96|pg10|pg11)$ ]]; then
+if [[ "$PGVER" =~ ^(pg94|pg95|pg96|pg10|pg11|pg12)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 cp settings.env step04_omero_patch_openssl.sh step04_all_omero.sh setup_omero_db.sh ~omero-server

--- a/linux/install_debian9.sh
+++ b/linux/install_debian9.sh
@@ -27,7 +27,7 @@ bash -eux step01_debian9_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg94|pg95|pg96|pg10|pg11)$ ]]; then
+if [[ "$PGVER" =~ ^(pg94|pg95|pg96|pg10|pg11|pg12)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 cp settings.env step04_omero_patch_openssl.sh step04_all_omero.sh setup_omero_db.sh ~omero-server

--- a/linux/install_ubuntu1804.sh
+++ b/linux/install_ubuntu1804.sh
@@ -25,7 +25,7 @@ bash -eux step01_ubuntu1804_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg94|pg95|pg96|pg96|pg10|pg11)$ ]]; then
+if [[ "$PGVER" =~ ^(pg94|pg95|pg96|pg96|pg10|pg11|pg12)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 

--- a/linux/step01_centos7_pg_deps.sh
+++ b/linux/step01_centos7_pg_deps.sh
@@ -111,4 +111,24 @@ elif [ "$PGVER" = "pg11" ]; then
     fi
     systemctl enable postgresql-11.service
     #end-recommended
+elif [ "$PGVER" = "pg12" ]; then
+    yum -y install postgresql12-server postgresql12
+
+    if [ "${container:-}" = docker ]; then
+        su - postgres -c "/usr/pgsql-12/bin/initdb -D /var/lib/pgsql/12/data --encoding=UTF8"
+        echo "listen_addresses='*'" >> /var/lib/pgsql/11/data/postgresql.conf
+    else
+        PGSETUP_INITDB_OPTIONS=--encoding=UTF8 /usr/pgsql-12/bin/postgresql-12-setup initdb
+    fi
+    sed -i.bak -re 's/^(host.*)ident/\1md5/' /var/lib/pgsql/12/data/pg_hba.conf
+    if [ "${container:-}" = docker ]; then
+        sed -i 's/OOMScoreAdjust/#OOMScoreAdjust/' \
+        /usr/lib/systemd/system/postgresql-12.service
+    fi
+    if [ "${container:-}" = docker ]; then
+        su - postgres -c "/usr/pgsql-11/bin/pg_ctl start -D /var/lib/pgsql/12/data -w"
+    else
+        systemctl start postgresql-12.service
+    fi
+    systemctl enable postgresql-12.service
 fi

--- a/linux/step01_centos7_pg_deps.sh
+++ b/linux/step01_centos7_pg_deps.sh
@@ -116,7 +116,7 @@ elif [ "$PGVER" = "pg12" ]; then
 
     if [ "${container:-}" = docker ]; then
         su - postgres -c "/usr/pgsql-12/bin/initdb -D /var/lib/pgsql/12/data --encoding=UTF8"
-        echo "listen_addresses='*'" >> /var/lib/pgsql/11/data/postgresql.conf
+        echo "listen_addresses='*'" >> /var/lib/pgsql/12/data/postgresql.conf
     else
         PGSETUP_INITDB_OPTIONS=--encoding=UTF8 /usr/pgsql-12/bin/postgresql-12-setup initdb
     fi
@@ -126,7 +126,7 @@ elif [ "$PGVER" = "pg12" ]; then
         /usr/lib/systemd/system/postgresql-12.service
     fi
     if [ "${container:-}" = docker ]; then
-        su - postgres -c "/usr/pgsql-11/bin/pg_ctl start -D /var/lib/pgsql/12/data -w"
+        su - postgres -c "/usr/pgsql-12/bin/pg_ctl start -D /var/lib/pgsql/12/data -w"
     else
         systemctl start postgresql-12.service
     fi

--- a/linux/step01_debian10_pg_deps.sh
+++ b/linux/step01_debian10_pg_deps.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 PGVER=${PGVER:-pg11}
+
 if [[ "$PGVER" =~ ^(pg94|pg95|pg10)$ ]]; then
     PGVER="pg11"
 fi
@@ -8,6 +9,13 @@ fi
 if [ "$PGVER" = "pg11" ]; then
     #start-recommended
     apt-get install -y postgresql-11
-	service postgresql start
+    service postgresql start
     #end-recommended
+elif [ "$PGVER" = "pg12" ]; then
+    apt-get -y install gnupg2
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    apt-get update
+    apt-get install -y postgresql-12
+    service postgresql start
 fi

--- a/linux/step01_debian9_pg_deps.sh
+++ b/linux/step01_debian9_pg_deps.sh
@@ -27,12 +27,10 @@ elif [ "$PGVER" = "pg11" ]; then
     service postgresql start
     #end-recommended
 elif [ "$PGVER" = "pg12" ]; then
-    #start-recommended
     apt-get install -y gnupg
     echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/pgdg.list
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     apt-get update
     apt-get install -y postgresql-12
     service postgresql start
-    #end-recommended
 fi

--- a/linux/step01_debian9_pg_deps.sh
+++ b/linux/step01_debian9_pg_deps.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 PGVER=${PGVER:-pg11}
+
 if [[ "$PGVER" =~ ^(pg94|pg95)$ ]]; then
     PGVER="pg11"
 fi
@@ -23,6 +24,15 @@ elif [ "$PGVER" = "pg11" ]; then
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     apt-get update
     apt-get install -y postgresql-11
+    service postgresql start
+    #end-recommended
+elif [ "$PGVER" = "pg12" ]; then
+    #start-recommended
+    apt-get install -y gnupg
+    echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    apt-get update
+    apt-get install -y postgresql-12
     service postgresql start
     #end-recommended
 fi

--- a/linux/step01_ubuntu1804_pg_deps.sh
+++ b/linux/step01_ubuntu1804_pg_deps.sh
@@ -17,12 +17,10 @@ elif [ "$PGVER" = "pg11" ]; then
     service postgresql start
     #end-recommended
 elif [ "$PGVER" = "pg12" ]; then
-    #start-recommended
     apt-get install -y gnupg
     echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" > /etc/apt/sources.list.d/pgdg.list
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     apt-get update
     apt-get -y install postgresql-12
     service postgresql start
-    #end-recommended
 fi

--- a/linux/step01_ubuntu1804_pg_deps.sh
+++ b/linux/step01_ubuntu1804_pg_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PGVER=${PGVER:-pg11}
-
+PGVER=pg12
 #Postgres 10
 if [ "$PGVER" = "pg10" ]; then
     apt-get update
@@ -14,6 +14,15 @@ elif [ "$PGVER" = "pg11" ]; then
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     apt-get update
     apt-get -y install postgresql-11
+    service postgresql start
+    #end-recommended
+elif [ "$PGVER" = "pg12" ]; then
+    #start-recommended
+    apt-get install -y gnupg
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    apt-get update
+    apt-get -y install postgresql-12
     service postgresql start
     #end-recommended
 fi


### PR DESCRIPTION
This PR adds support for pg12 on centos7, debian9/10 and ubuntu18.04
This is not marked as the recommended version

Installation is tested via travis
Check that travis is green