### PR TITLE
debian10: remove conf for openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,8 @@ env:
   - ENV=ubuntu1804
   - ENV=centos7
   - ENV=debian10
-
-jobs:
-  allow_failures:
-    - ENV=ubuntu2004
-    - ENV=centos8
+  - ENV=ubuntu2004
+  - ENV=centos8
 
 
 before_install:  

--- a/linux/step01_debian10_deps.sh
+++ b/linux/step01_debian10_deps.sh
@@ -3,7 +3,3 @@
 apt-get -y install\
     python3 \
     python3-venv
-
-# Fix openssl issues
-sed -e '/MinProtocol/ s/^#*/#/' -i /etc/ssl/openssl.cnf
-sed -e '/CipherString/ s/^#*/#/' -i /etc/ssl/openssl.cnf

--- a/linux/step04_all_omero_install.sh
+++ b/linux/step04_all_omero_install.sh
@@ -8,7 +8,9 @@ set -eux
 
 #start-install-omero-py
 # Install omero-py
-$VENV_SERVER/bin/pip install "omero-py>=5.6.0"
+#$VENV_SERVER/bin/pip install "omero-py>=5.6.0"
+wget https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-python-superbuild-build/lastSuccessfulBuild/artifact/omero-py/dist/omero-py-5.7.2.dev0.tar.gz
+$VENV_SERVER/bin/pip install omero-py-5.7.2.dev0.tar.gz
 #end-install-omero-py
 
 #start-download-omero

--- a/linux/step04_all_omero_install.sh
+++ b/linux/step04_all_omero_install.sh
@@ -8,9 +8,7 @@ set -eux
 
 #start-install-omero-py
 # Install omero-py
-#$VENV_SERVER/bin/pip install "omero-py>=5.6.0"
-wget https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-python-superbuild-build/lastSuccessfulBuild/artifact/omero-py/dist/omero-py-5.7.2.dev0.tar.gz
-$VENV_SERVER/bin/pip install omero-py-5.7.2.dev0.tar.gz
+$VENV_SERVER/bin/pip install "omero-py>=5.8.0"
 #end-install-omero-py
 
 #start-download-omero


### PR DESCRIPTION
Adding support for multiple Ice protocols see https://github.com/ome/omero-py/pull/251
means that modifying the openssl.cnf is no longer required.

After removing the conf changes,
```
su - omero-server -c ". ~/settings.env && omero login -s localhost -p 4064 -u root -w omero_root_password"
WARNING:omero.client:..Ignoring error in client.__del__:<class 'Ice.SocketException'>
InternalException: Failed to connect: Ice.SocketException:
Cannot assign requested address
```

Applying the change from https://github.com/ome/omero-py/pull/251 directly to  ``/opt/omero/server/venv3/lib/python3.7/site-packages/omero/clients.py``

```
su - omero-server -c ". ~/settings.env && omero login -s localhost -p 4064 -u root -w omero_root_password"
Created session for root@localhost:4064. Idle timeout: 10 min. Current group: system
```

cc @mtbc 

Edit
----
 * Travis will not be green until we have a new release of omero with a new version of omero
 * re-activate C8 and ubuntu 20.04 to simplify things since we need to use the daily build to test. Commit 5fa98b8 could be pushed away when we are happy with the state of things.
