### PR TITLE
import an image

### DIFF
--- a/linux/test/test_services.sh
+++ b/linux/test/test_services.sh
@@ -49,6 +49,9 @@ docker exec -it $CNAME /bin/bash -c "su - omero-server -c \". ${SETTINGS} && ome
 
 docker exec -it $CNAME /bin/bash -c "su - omero-server -c \". ${SETTINGS} && touch test_image.fake && omero import test_image.fake\""
 
+# Log out
+docker exec -it $CNAME /bin/bash -c "su - omero-server -c \". ${SETTINGS} && omero logout\""
+
 # stop and cleanup
 docker stop $CNAME
 docker rm $CNAME

--- a/linux/test/test_services.sh
+++ b/linux/test/test_services.sh
@@ -9,7 +9,6 @@ DMNAME=${DMNAME:-dev}
 
 CNAME=omeroinstall_$ENV
 SETTINGS=${SETTINGS:-/home/omero-server/settings.env}
-DATA=https://downloads.openmicroscopy.org/images/PNG/will/WesternBlots/Blot-purif-Ab-west-11.11.png
 
 # start docker container
 docker run -dit --name $CNAME -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /run -p 8080:80 omero_install_test_$ENV
@@ -48,7 +47,7 @@ docker exec -it $CNAME /bin/bash -c "su - omero-server -c \". ${SETTINGS} && ome
 # Log in to OMERO.server
 docker exec -it $CNAME /bin/bash -c "su - omero-server -c \". ${SETTINGS} && omero login -s localhost -p 4064 -u root -w ${OMERO_ROOT_PASS}\""
 
-docker exec -it $CNAME /bin/bash -c "su - omero-server -c \". ${SETTINGS} && wget ${DATA} -O image.png && omero import image.png\""
+docker exec -it $CNAME /bin/bash -c "su - omero-server -c \". ${SETTINGS} && touch test_image.fake && omero import test_image.fake\""
 
 # stop and cleanup
 docker stop $CNAME

--- a/linux/test/test_services.sh
+++ b/linux/test/test_services.sh
@@ -9,6 +9,7 @@ DMNAME=${DMNAME:-dev}
 
 CNAME=omeroinstall_$ENV
 SETTINGS=${SETTINGS:-/home/omero-server/settings.env}
+DATA=https://downloads.openmicroscopy.org/images/PNG/will/WesternBlots/Blot-purif-Ab-west-11.11.png
 
 # start docker container
 docker run -dit --name $CNAME -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /run -p 8080:80 omero_install_test_$ENV
@@ -46,6 +47,8 @@ docker exec -it $CNAME /bin/bash -c "su - omero-server -c \". ${SETTINGS} && ome
 
 # Log in to OMERO.server
 docker exec -it $CNAME /bin/bash -c "su - omero-server -c \". ${SETTINGS} && omero login -s localhost -p 4064 -u root -w ${OMERO_ROOT_PASS}\""
+
+docker exec -it $CNAME /bin/bash -c "su - omero-server -c \". ${SETTINGS} && wget ${DATA} -O image.png && omero import image.png\""
 
 # stop and cleanup
 docker stop $CNAME


### PR DESCRIPTION
As suggested by @mtbc while reviewing https://github.com/ome/omero-py/pull/251
I have added an "import" step to the test.
I have tested in the context of https://github.com/ome/omero-install/pull/245
```
2020-09-11 12:03:47,707 5815       [2-thread-1] INFO   ormats.importer.cli.LoggingImportMonitor - FILESET_UPLOAD_PREPARATION
2020-09-11 12:03:48,835 6943       [2-thread-1] INFO   ormats.importer.cli.LoggingImportMonitor - FILESET_UPLOAD_START
2020-09-11 12:03:48,915 7023       [3-thread-1] INFO   ts.importer.transfers.UploadFileTransfer - Transferring /home/omero-server/image.png...
2020-09-11 12:03:49,013 7121       [3-thread-1] INFO   ormats.importer.cli.LoggingImportMonitor - FILE_UPLOAD_STARTED: /home/omero-server/image.png
2020-09-11 12:03:49,075 7183       [3-thread-1] INFO   ormats.importer.cli.LoggingImportMonitor - FILE_UPLOAD_COMPLETE: /home/omero-server/image.png
2020-09-11 12:03:49,310 7418       [2-thread-1] INFO   ormats.importer.cli.LoggingImportMonitor - FILESET_UPLOAD_END
2020-09-11 12:03:49,828 7936       [2-thread-1] INFO   ormats.importer.cli.LoggingImportMonitor - IMPORT_STARTED Logfile: 77
2020-09-11 12:03:50,696 8804       [l.Client-1] INFO   ormats.importer.cli.LoggingImportMonitor - METADATA_IMPORTED Step: 1 of 5  Logfile: 77
2020-09-11 12:03:51,272 9380       [l.Client-0] INFO   ormats.importer.cli.LoggingImportMonitor - PIXELDATA_PROCESSED Step: 2 of 5  Logfile: 77
2020-09-11 12:03:52,411 10519      [l.Client-1] INFO   ormats.importer.cli.LoggingImportMonitor - THUMBNAILS_GENERATED Step: 3 of 5  Logfile: 77
2020-09-11 12:03:52,449 10557      [l.Client-0] INFO   ormats.importer.cli.LoggingImportMonitor - METADATA_PROCESSED Step: 4 of 5  Logfile: 77
2020-09-11 12:03:52,482 10590      [l.Client-0] INFO   ormats.importer.cli.LoggingImportMonitor - OBJECTS_RETURNED Step: 5 of 5  Logfile: 77
2020-09-11 12:03:52,744 10852      [l.Client-1] INFO   ormats.importer.cli.LoggingImportMonitor - IMPORT_DONE Imported file: /home/omero-server/image.png
Image:1
Other imported objects:
Fileset:1

==> Summary
1 file uploaded, 1 fileset created, 1 image imported, 0 errors in 0:00:05.068
+ docker stop omeroinstall_debian10
omeroinstall_debian10
+ docker rm omeroinstall_debian10
omeroinstall_debian10
```

