### PR TITLE
Remove ``omero-py`` install step. Already pulled via ``omero-server[x]``

### DIFF
--- a/linux/autogenerate.sh
+++ b/linux/autogenerate.sh
@@ -176,13 +176,7 @@ echo "$line" >> $file
 echo "#end-step03bis" >> $file
 
 echo -en '\n' >> $file
-echo "#start-step04-pre: As root, install omero-py and download the OMERO.server" >> $file
-start=$(sed -n '/#start-install-omero-py/=' $dir/step04_all_omero_install.sh)
-start=$((start+1))
-number=$(sed -n '/#end-install-omero-py/=' $dir/step04_all_omero_install.sh)
-ne=$((number-1))
-line=$(sed -n ''$start','$ne'p' $dir/step04_all_omero_install.sh)
-echo "$line" >> $file
+echo "#start-step04-pre: As root, download the OMERO.server" >> $file
 echo "#start-release-ice36" >> $file
 number=$(sed -n '/#start-release-ice36/=' $dir/step04_all_omero_install.sh)
 ns=$((number+1))

--- a/linux/step01_centos7_ice_venv.sh
+++ b/linux/step01_centos7_ice_venv.sh
@@ -4,8 +4,11 @@ set -e -u -x
 
 VENV_SERVER=${VENV_SERVER:-/opt/omero/server/venv3}
 #start-ice-py
-# Create a virtual env and activate it
+# Create a virtual env
 python3 -mvenv $VENV_SERVER
+
+# Upgrade pip
+$VENV_SERVER/bin/pip install --upgrade pip
 
 # Install the Ice Python binding
 $VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl

--- a/linux/step01_centos8_ice_venv.sh
+++ b/linux/step01_centos8_ice_venv.sh
@@ -4,8 +4,11 @@ set -e -u -x
 
 VENV_SERVER=${VENV_SERVER:-/opt/omero/server/venv3}
 #start-ice-py
-# Create a virtual env and activate it
+# Create a virtual env
 python3 -mvenv $VENV_SERVER
+
+# Upgrade pip
+$VENV_SERVER/bin/pip install --upgrade pip
 
 # Install the Ice Python binding
 $VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-centos8/releases/download/0.0.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl

--- a/linux/step01_debian10_ice_venv.sh
+++ b/linux/step01_debian10_ice_venv.sh
@@ -4,8 +4,11 @@ set  -x
 
 VENV_SERVER=${VENV_SERVER:-/opt/omero/server/venv3}
 #start-ice-py
-# Create a virtual env and activate it
+# Create a virtual env
 python3 -mvenv $VENV_SERVER
+
+# Upgrade pip
+$VENV_SERVER/bin/pip install --upgrade pip
 
 # Install the Ice Python binding
 $VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-debian10/releases/download/0.1.0/zeroc_ice-3.6.5-cp37-cp37m-linux_x86_64.whl

--- a/linux/step01_debian9_ice_venv.sh
+++ b/linux/step01_debian9_ice_venv.sh
@@ -4,8 +4,11 @@ set  -x
 
 VENV_SERVER=${VENV_SERVER:-/opt/omero/server/venv3}
 #start-ice-py
-# Create a virtual env and activate it
+# Create a virtual env
 python3 -mvenv $VENV_SERVER
+
+# Upgrade pip
+$VENV_SERVER/bin/pip install --upgrade pip
 
 # Install the Ice Python binding
 $VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-py-debian9/releases/download/0.2.0/zeroc_ice-3.6.5-cp35-cp35m-linux_x86_64.whl

--- a/linux/step01_ubuntu1804_ice_venv.sh
+++ b/linux/step01_ubuntu1804_ice_venv.sh
@@ -4,8 +4,11 @@ set -e -u -x
 
 VENV_SERVER=${VENV_SERVER:-/opt/omero/server/venv3}
 #start-ice-py
-# Create a virtual env and activate it
+# Create a virtual env
 python3 -mvenv $VENV_SERVER
+
+# Upgrade pip
+$VENV_SERVER/bin/pip install --upgrade pip
 
 # Install the Ice Python binding
 $VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-ubuntu1804/releases/download/0.3.0/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl

--- a/linux/step01_ubuntu2004_ice_venv.sh
+++ b/linux/step01_ubuntu2004_ice_venv.sh
@@ -4,8 +4,11 @@ set -e -u -x
 
 VENV_SERVER=${VENV_SERVER:-/opt/omero/server/venv3}
 #start-ice-py
-# Create a virtual env and activate it
+# Create a virtual env
 python3 -mvenv $VENV_SERVER
+
+# Upgrade pip
+$VENV_SERVER/bin/pip install --upgrade pip
 
 # Install the Ice Python binding
 $VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-ubuntu2004/releases/download/0.2.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl

--- a/linux/step04_all_omero_install.sh
+++ b/linux/step04_all_omero_install.sh
@@ -6,13 +6,6 @@ set -eux
 
 . `dirname $0`/settings.env
 
-#start-install-omero-py
-# Install omero-py
-$VENV_SERVER/bin/pip install "omero-py>=5.8.0"
-#end-install-omero-py
-
-#start-download-omero
-
 
 #start-install
 if [ "$ICEVER" = "ice36" ]; then

--- a/linux/test/centos7/Dockerfile
+++ b/linux/test/centos7/Dockerfile
@@ -13,6 +13,8 @@ RUN userdel -r omero && \
 	echo 'root:omero' | chpasswd
 
 ADD omero-install-test.zip /
+RUN yum update -y
+RUN yum -y install ca-certificates
 RUN yum -y install initscripts unzip && unzip omero-install-test.zip
 
 


### PR DESCRIPTION
* Remove ``omero-py`` installation step. This is already installed by ``pip install omero-server[x]``
* Upgrade ``pip`` otherwise the installation of the python dependencies using ``pip`` fail
* Upgrade centos7 image. Change to be applied to https://github.com/ome/omero-ssh-c7-docker 