### PR TITLE
CentOS 8 and Python 3.8

### DIFF
--- a/linux/step01_centos8_deps.sh
+++ b/linux/step01_centos8_deps.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-yum -y install python3
+yum -y install python38
 yum -y install openssl

--- a/linux/step01_centos8_ice_deps.sh
+++ b/linux/step01_centos8_ice_deps.sh
@@ -13,9 +13,9 @@ if [ "$ICEVER" = "ice36" ]; then
         libmcpp
 
     cd /tmp
-    wget -q https://github.com/ome/zeroc-ice-centos8/releases/download/0.0.1/ice-3.6.5-0.0.1-centos8-amd64.tar.gz
-    tar xf ice-3.6.5-0.0.1-centos8-amd64.tar.gz
-    mv ice-3.6.5-0.0.1 ice-3.6.5
+    wget -q https://github.com/ome/zeroc-ice-centos8/releases/download/0.1.0/ice-3.6.5-0.1.0-centos8-amd64.tar.gz
+    tar xf ice-3.6.5-0.1.0-centos8-amd64.tar.gz
+    mv ice-3.6.5-0.1.0 ice-3.6.5
     mv ice-3.6.5 /opt
     echo /opt/ice-3.6.5/lib64 > /etc/ld.so.conf.d/ice-x86_64.conf
     ldconfig

--- a/linux/step01_centos8_ice_venv.sh
+++ b/linux/step01_centos8_ice_venv.sh
@@ -11,7 +11,7 @@ python3 -mvenv $VENV_SERVER
 $VENV_SERVER/bin/pip install --upgrade pip
 
 # Install the Ice Python binding
-$VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-centos8/releases/download/0.2.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl
+$VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-centos8/releases/download/0.1.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl
 
 # Install server dependencies
 $VENV_SERVER/bin/pip install omero-server[default]

--- a/linux/step01_centos8_ice_venv.sh
+++ b/linux/step01_centos8_ice_venv.sh
@@ -11,7 +11,7 @@ python3 -mvenv $VENV_SERVER
 $VENV_SERVER/bin/pip install --upgrade pip
 
 # Install the Ice Python binding
-$VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-centos8/releases/download/0.0.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
+$VENV_SERVER/bin/pip install https://github.com/ome/zeroc-ice-centos8/releases/download/0.2.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl
 
 # Install server dependencies
 $VENV_SERVER/bin/pip install omero-server[default]


### PR DESCRIPTION
Changes required to run OMERO on CentOS 8 with Python 3.8 (default is 3.6)
The wheel/zip currently available at https://github.com/jburel/zeroc-ice-centos8/releases/tag/0.0.2 will need to be moved to ``ome``.

cc @joshmoore @sbesson 