### PR TITLE
Psql update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu2004, ubuntu1804, debian10, centos7]
-        pg: [pg11, pg12, pg14, pg13]
+        os: [centos7, debian10, ubuntu1804, ubuntu2004]
+        pg: [pg11, pg12, pg13, pg14]
         exclude:
           - os: ubuntu2004
             pg: pg11

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu1804]
-        pg: [pg11, pg14]
+        os: [ubuntu2004, ubuntu1804, debian10, centos7]
+        pg: [pg11, pg12, pg14]
         exclude:
           - os: ubuntu2004
             pg: pg11

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [centos7, debian10, ubuntu1804, ubuntu2004]
-        pg: [pg11, pg12]
+        os: [ubuntu1804]
+        pg: [pg11, pg14]
         exclude:
           - os: ubuntu2004
             pg: pg11

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu2004, ubuntu1804, debian10, centos7]
-        pg: [pg11, pg12, pg14]
+        pg: [pg11, pg12, pg14, pg13]
         exclude:
           - os: ubuntu2004
             pg: pg11

--- a/linux/install_centos7.sh
+++ b/linux/install_centos7.sh
@@ -23,7 +23,7 @@ bash -eux step01_centos7_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg10|pg11|pg12)$ ]]; then
+if [[ "$PGVER" =~ ^(pg10|pg11|pg12|pg14)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 

--- a/linux/install_centos7.sh
+++ b/linux/install_centos7.sh
@@ -23,7 +23,7 @@ bash -eux step01_centos7_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg10|pg11|pg12|pg14)$ ]]; then
+if [[ "$PGVER" =~ ^(pg11|pg12|pg14)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 

--- a/linux/install_centos7.sh
+++ b/linux/install_centos7.sh
@@ -23,7 +23,7 @@ bash -eux step01_centos7_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg11|pg12|pg14)$ ]]; then
+if [[ "$PGVER" =~ ^(pg11|pg12|pg13|pg14)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 

--- a/linux/install_debian10.sh
+++ b/linux/install_debian10.sh
@@ -27,7 +27,7 @@ bash -eux step01_debian10_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg11|pg12|pg14)$ ]]; then
+if [[ "$PGVER" =~ ^(pg11|pg12|pg13|pg14)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 cp settings.env step04_all_omero.sh setup_omero_db.sh ~omero-server

--- a/linux/install_debian10.sh
+++ b/linux/install_debian10.sh
@@ -27,7 +27,7 @@ bash -eux step01_debian10_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg11|pg12)$ ]]; then
+if [[ "$PGVER" =~ ^(pg11|pg12|pg14)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 cp settings.env step04_all_omero.sh setup_omero_db.sh ~omero-server

--- a/linux/install_ubuntu1804.sh
+++ b/linux/install_ubuntu1804.sh
@@ -25,7 +25,7 @@ bash -eux step01_ubuntu1804_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg10|pg11|pg12)$ ]]; then
+if [[ "$PGVER" =~ ^(pg10|pg11|pg12|pg14)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 

--- a/linux/install_ubuntu1804.sh
+++ b/linux/install_ubuntu1804.sh
@@ -25,7 +25,7 @@ bash -eux step01_ubuntu1804_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg11|pg12|g13|pg14)$ ]]; then
+if [[ "$PGVER" =~ ^(pg11|pg12|pg13|pg14)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 

--- a/linux/install_ubuntu1804.sh
+++ b/linux/install_ubuntu1804.sh
@@ -25,7 +25,7 @@ bash -eux step01_ubuntu1804_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg10|pg11|pg12|pg14)$ ]]; then
+if [[ "$PGVER" =~ ^(pg11|pg12|pg14)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 

--- a/linux/install_ubuntu1804.sh
+++ b/linux/install_ubuntu1804.sh
@@ -25,7 +25,7 @@ bash -eux step01_ubuntu1804_pg_deps.sh
 
 bash -eux step02_all_setup.sh
 
-if [[ "$PGVER" =~ ^(pg11|pg12|pg14)$ ]]; then
+if [[ "$PGVER" =~ ^(pg11|pg12|g13|pg14)$ ]]; then
     bash -eux step03_all_postgres.sh
 fi
 

--- a/linux/step01_centos7_pg_deps.sh
+++ b/linux/step01_centos7_pg_deps.sh
@@ -49,7 +49,7 @@ elif [ "$PGVER" = "pg12" ]; then
     fi
     systemctl enable postgresql-12.service
 elif [ "$PGVER" = "pg13" ]; then
-    yum -y install postgresql13-server postgresql14
+    yum -y install postgresql13-server postgresql13
 
     if [ "${container:-}" = docker ]; then
         su - postgres -c "/usr/pgsql-13/bin/initdb -D /var/lib/pgsql/13/data --encoding=UTF8"

--- a/linux/step01_centos7_pg_deps.sh
+++ b/linux/step01_centos7_pg_deps.sh
@@ -68,4 +68,24 @@ elif [ "$PGVER" = "pg12" ]; then
         systemctl start postgresql-12.service
     fi
     systemctl enable postgresql-12.service
+elif [ "$PGVER" = "pg14" ]; then
+    yum -y install postgresql14-server postgresql14
+
+    if [ "${container:-}" = docker ]; then
+        su - postgres -c "/usr/pgsql-14/bin/initdb -D /var/lib/pgsql/14/data --encoding=UTF8"
+        echo "listen_addresses='*'" >> /var/lib/pgsql/14/data/postgresql.conf
+    else
+        PGSETUP_INITDB_OPTIONS=--encoding=UTF8 /usr/pgsql-12/bin/postgresql-14-setup initdb
+    fi
+    sed -i.bak -re 's/^(host.*)ident/\1md5/' /var/lib/pgsql/14/data/pg_hba.conf
+    if [ "${container:-}" = docker ]; then
+        sed -i 's/OOMScoreAdjust/#OOMScoreAdjust/' \
+        /usr/lib/systemd/system/postgresql-14.service
+    fi
+    if [ "${container:-}" = docker ]; then
+        su - postgres -c "/usr/pgsql-14/bin/pg_ctl start -D /var/lib/pgsql/14/data -w"
+    else
+        systemctl start postgresql-14.service
+    fi
+    systemctl enable postgresql-14.service
 fi

--- a/linux/step01_centos7_pg_deps.sh
+++ b/linux/step01_centos7_pg_deps.sh
@@ -6,27 +6,7 @@ PGVER=${PGVER:-pg11}
 #start-postgresql-installation-general
 yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 #end-postgresql-installation-general
-if [ "$PGVER" = "pg10" ]; then
-    yum -y install postgresql10-server postgresql10
-
-    if [ "${container:-}" = docker ]; then
-        su - postgres -c "/usr/pgsql-10/bin/initdb -D /var/lib/pgsql/10/data --encoding=UTF8"
-        echo "listen_addresses='*'" >> /var/lib/pgsql/10/data/postgresql.conf
-    else
-        PGSETUP_INITDB_OPTIONS=--encoding=UTF8 /usr/pgsql-10/bin/postgresql-10-setup initdb
-    fi
-    sed -i.bak -re 's/^(host.*)ident/\1md5/' /var/lib/pgsql/10/data/pg_hba.conf
-    if [ "${container:-}" = docker ]; then
-        sed -i 's/OOMScoreAdjust/#OOMScoreAdjust/' \
-        /usr/lib/systemd/system/postgresql-10.service
-    fi
-    if [ "${container:-}" = docker ]; then
-        su - postgres -c "/usr/pgsql-10/bin/pg_ctl start -D /var/lib/pgsql/10/data -w"
-    else
-        systemctl start postgresql-10.service
-    fi
-    systemctl enable postgresql-10.service
-elif [ "$PGVER" = "pg11" ]; then
+if [ "$PGVER" = "pg11" ]; then
     #start-recommended
     yum -y install postgresql11-server postgresql11
 

--- a/linux/step01_centos7_pg_deps.sh
+++ b/linux/step01_centos7_pg_deps.sh
@@ -48,6 +48,26 @@ elif [ "$PGVER" = "pg12" ]; then
         systemctl start postgresql-12.service
     fi
     systemctl enable postgresql-12.service
+elif [ "$PGVER" = "pg13" ]; then
+    yum -y install postgresql13-server postgresql14
+
+    if [ "${container:-}" = docker ]; then
+        su - postgres -c "/usr/pgsql-13/bin/initdb -D /var/lib/pgsql/13/data --encoding=UTF8"
+        echo "listen_addresses='*'" >> /var/lib/pgsql/13/data/postgresql.conf
+    else
+        PGSETUP_INITDB_OPTIONS=--encoding=UTF8 /usr/pgsql-13/bin/postgresql-13-setup initdb
+    fi
+    sed -i.bak -re 's/^(host.*)ident/\1md5/' /var/lib/pgsql/13/data/pg_hba.conf
+    if [ "${container:-}" = docker ]; then
+        sed -i 's/OOMScoreAdjust/#OOMScoreAdjust/' \
+        /usr/lib/systemd/system/postgresql-13.service
+    fi
+    if [ "${container:-}" = docker ]; then
+        su - postgres -c "/usr/pgsql-13/bin/pg_ctl start -D /var/lib/pgsql/13/data -w"
+    else
+        systemctl start postgresql-13.service
+    fi
+    systemctl enable postgresql-13.service
 elif [ "$PGVER" = "pg14" ]; then
     yum -y install postgresql14-server postgresql14
 
@@ -55,7 +75,7 @@ elif [ "$PGVER" = "pg14" ]; then
         su - postgres -c "/usr/pgsql-14/bin/initdb -D /var/lib/pgsql/14/data --encoding=UTF8"
         echo "listen_addresses='*'" >> /var/lib/pgsql/14/data/postgresql.conf
     else
-        PGSETUP_INITDB_OPTIONS=--encoding=UTF8 /usr/pgsql-12/bin/postgresql-14-setup initdb
+        PGSETUP_INITDB_OPTIONS=--encoding=UTF8 /usr/pgsql-14/bin/postgresql-14-setup initdb
     fi
     sed -i.bak -re 's/^(host.*)ident/\1md5/' /var/lib/pgsql/14/data/pg_hba.conf
     if [ "${container:-}" = docker ]; then

--- a/linux/step01_debian10_pg_deps.sh
+++ b/linux/step01_debian10_pg_deps.sh
@@ -14,6 +14,13 @@ elif [ "$PGVER" = "pg12" ]; then
     apt-get update
     apt-get install -y postgresql-12
     service postgresql start
+elif [ "$PGVER" = "pg13" ]; then
+    apt-get -y install gnupg2
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    apt-get update
+    apt-get install -y postgresql-13
+    service postgresql start
 elif [ "$PGVER" = "pg14" ]; then
     apt-get -y install gnupg2
     echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list

--- a/linux/step01_debian10_pg_deps.sh
+++ b/linux/step01_debian10_pg_deps.sh
@@ -14,4 +14,11 @@ elif [ "$PGVER" = "pg12" ]; then
     apt-get update
     apt-get install -y postgresql-12
     service postgresql start
+elif [ "$PGVER" = "pg14" ]; then
+    apt-get -y install gnupg2
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    apt-get update
+    apt-get install -y postgresql-14
+    service postgresql start
 fi

--- a/linux/step01_ubuntu1804_pg_deps.sh
+++ b/linux/step01_ubuntu1804_pg_deps.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 PGVER=${PGVER:-pg11}
-PGVER=pg12
 #Postgres 10
 if [ "$PGVER" = "pg10" ]; then
     apt-get update
@@ -22,5 +21,12 @@ elif [ "$PGVER" = "pg12" ]; then
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     apt-get update
     apt-get -y install postgresql-12
+    service postgresql start
+elif [ "$PGVER" = "pg14" ]; then
+    apt-get install -y gnupg
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    apt-get update
+    apt-get -y install postgresql-14
     service postgresql start
 fi

--- a/linux/step01_ubuntu1804_pg_deps.sh
+++ b/linux/step01_ubuntu1804_pg_deps.sh
@@ -18,6 +18,13 @@ elif [ "$PGVER" = "pg12" ]; then
     apt-get update
     apt-get -y install postgresql-12
     service postgresql start
+elif [ "$PGVER" = "pg13" ]; then
+    apt-get install -y gnupg
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    apt-get update
+    apt-get -y install postgresql-13
+    service postgresql start
 elif [ "$PGVER" = "pg14" ]; then
     apt-get install -y gnupg
     echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" > /etc/apt/sources.list.d/pgdg.list

--- a/linux/step01_ubuntu1804_pg_deps.sh
+++ b/linux/step01_ubuntu1804_pg_deps.sh
@@ -2,11 +2,7 @@
 
 PGVER=${PGVER:-pg11}
 #Postgres 10
-if [ "$PGVER" = "pg10" ]; then
-    apt-get update
-    apt-get -y install postgresql
-    service postgresql start
-elif [ "$PGVER" = "pg11" ]; then
+if [ "$PGVER" = "pg11" ]; then
     #start-recommended
     apt-get install -y gnupg
     echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" > /etc/apt/sources.list.d/pgdg.list

--- a/linux/step01_ubuntu2004_pg_deps.sh
+++ b/linux/step01_ubuntu2004_pg_deps.sh
@@ -3,9 +3,18 @@
 PGVER=${PGVER:-pg12}
 
 #Postgres 12
-#start-recommended
-apt-get update
-apt-get -y install postgresql
-service postgresql start
-#end-recommended
+if [ "$PGVER" = "pg12" ]; then
+    #start-recommended
+    apt-get update
+    apt-get -y install postgresql
+    service postgresql start
+    #end-recommended
+elif [ "$PGVER" = "pg14" ]; then
+	apt-get install -y gnupg
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    apt-get update
+    apt-get -y install postgresql-14
+    service postgresql start
+fi
 

--- a/linux/step01_ubuntu2004_pg_deps.sh
+++ b/linux/step01_ubuntu2004_pg_deps.sh
@@ -9,8 +9,15 @@ if [ "$PGVER" = "pg12" ]; then
     apt-get -y install postgresql
     service postgresql start
     #end-recommended
+elif [ "$PGVER" = "pg13" ]; then
+    apt-get install -y gnupg
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    apt-get update
+    apt-get -y install postgresql-13
+    service postgresql start
 elif [ "$PGVER" = "pg14" ]; then
-	apt-get install -y gnupg
+    apt-get install -y gnupg
     echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     apt-get update

--- a/linux/test/README.md
+++ b/linux/test/README.md
@@ -94,7 +94,7 @@ For example:
 
 
 The supported values are: 
-pg10, pg11 (default), pg12 (ubuntu 20.04 only)
+pg11 (default), pg12 (ubuntu 20.04 only), pg14
 
 If you do not want to install Postgres set PGVER to nopg.
 

--- a/linux/test/README.md
+++ b/linux/test/README.md
@@ -94,7 +94,7 @@ For example:
 
 
 The supported values are: 
-pg11 (default), pg12 (ubuntu 20.04 only), pg14
+pg11 (default), pg12 (ubuntu 20.04 only), pg13, pg14
 
 If you do not want to install Postgres set PGVER to nopg.
 


### PR DESCRIPTION
This PR
* adds installation instructions for pg14 and pg13
* tests installations via GHA
* removes pg10 installation instructions (ubuntu18.04 and CentOS 7). This was not tested via GHA

Remaining question: do we want to upgrade the recommended version i.e. pg11->pg14/13?


see also https://github.com/ome/omero-documentation/pull/2262