### PR TITLE
Pg install apt-key

### DIFF
--- a/linux/step01_ubuntu2204_pg_deps.sh
+++ b/linux/step01_ubuntu2204_pg_deps.sh
@@ -11,7 +11,7 @@ elif [ "$PGVER" = "pg15" ]; then
   apt-get install -y curl ca-certificates
   install -d /usr/share/postgresql-common/pgdg
   curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
-  sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+  sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt jammy-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
   apt-get update
   apt-get -y install postgresql-15
@@ -21,7 +21,7 @@ elif [ "$PGVER" = "pg16" ]; then
   apt-get install -y curl ca-certificates
   install -d /usr/share/postgresql-common/pgdg
   curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
-  sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+  sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt jammy-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
   apt-get update
   apt-get -y install postgresql-16
   service postgresql start

--- a/linux/step01_ubuntu2204_pg_deps.sh
+++ b/linux/step01_ubuntu2204_pg_deps.sh
@@ -8,17 +8,20 @@ if [ "$PGVER" = "pg14" ]; then
   service postgresql start
 elif [ "$PGVER" = "pg15" ]; then
   #start-recommended
-  apt-get install -y gnupg
-  echo "deb http://apt.postgresql.org/pub/repos/apt jammy-pgdg main" > /etc/apt/sources.list.d/pgdg.list
-  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+  apt-get install -y curl ca-certificates
+  install -d /usr/share/postgresql-common/pgdg
+  curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+  sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+
   apt-get update
   apt-get -y install postgresql-15
   service postgresql start
     #end-recommended
 elif [ "$PGVER" = "pg16" ]; then
-  apt-get install -y gnupg
-  echo "deb http://apt.postgresql.org/pub/repos/apt jammy-pgdg main" > /etc/apt/sources.list.d/pgdg.list
-  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+  apt-get install -y curl ca-certificates
+  install -d /usr/share/postgresql-common/pgdg
+  curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+  sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
   apt-get update
   apt-get -y install postgresql-16
   service postgresql start


### PR DESCRIPTION
Remove the usage of the deprecated ``apt-key`` command.
This was noticed during an installation workshop

Check that the build is green in GHA