### PR TITLE
Change location where to download the file from

### DIFF
--- a/linux/step04_all_omero_install.sh
+++ b/linux/step04_all_omero_install.sh
@@ -8,9 +8,11 @@ set -eux
 
 #start-install
 if [ $OMEROVER == "latest" ]; then
+	# version number and ice version to be dropped
 	#start-release-ice36
 	cd /opt/omero/server
-	SERVER=https://downloads.openmicroscopy.org/omero/5.6/server-ice36.zip
+	SERVER=https://github.com/ome/openmicroscopy/releases/latest/download/OMERO.server-5.6.13-ice36.zip
+
 	wget -q $SERVER -O OMERO.server-ice36.zip
 	unzip -q OMERO.server*
 	#end-release-ice36


### PR DESCRIPTION
During a release the artifacts from Github and copy them to Dundee
Installing the server from non EU countries make the installation process painfully slow. This was noticed while installing from Japan
This PR installs the server using directly the zip from gh
Note that in order to avoid an update every time a new version of OMERO.server is released, the version number needs to be dropped, see https://github.com/ome/openmicroscopy/pull/6414

